### PR TITLE
添加CloudFlare支持+一个小feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ python run.py -c /path/to/config.json
 * `default` 系统访问外网默认IP
 * `public`使用公网ip(使用公网API查询)
 * `nku` NKU网关ip(只支持ipv4)
+* `none` 不更新ipv4/ipv6的DNS解析
 
 ### 配置示例
 ```json

--- a/dns/cloudflare.py
+++ b/dns/cloudflare.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+"""
+CloudFlare API
+CloudFlare 接口解析操作库
+https://api.cloudflare.com/#dns-records-for-a-zone-properties
+@author: TongYifan
+"""
+
+import json
+import logging as log
+
+try:
+    # python 2
+    from httplib import HTTPSConnection
+    import urllib
+except ImportError:
+    # python 3
+    from http.client import HTTPSConnection
+    import urllib.parse as urllib
+
+__author__ = 'TongYifan'
+
+ID = "AUTH EMAIL"  # CloudFlare 验证的是用户Email，等同于其他平台的userID
+TOKEN = "API KEY"
+PROXY = None  # 代理设置
+API_SITE = "api.cloudflare.com"
+
+
+def request(method, action, param=None, **params):
+    """
+        发送请求数据
+    """
+    if param:
+        params.update(param)
+
+    log.debug("$s %s : params:%s", action, params)
+    if PROXY:
+        conn = HTTPSConnection(PROXY)
+        conn.set_tunnel(API_SITE, 443)
+    else:
+        conn = HTTPSConnection(API_SITE)
+
+    if method in ['PUT', 'POST']:
+        # 从public_v(4,6)获取的IP是bytes类型，在json.dumps时会报TypeError
+        params['content'] = str(params.get('content'))
+        params = json.dumps(params)
+    else:
+        params = urllib.urlencode(params)
+    conn.request(method, '/client/v4/zones' + action, params,
+                 {"Content-type": "application/json",
+                  "X-Auth-Email": ID,
+                  "X-Auth-Key": TOKEN})
+    response = conn.getresponse()
+    res = response.read()
+    conn.close()
+    if response.status < 200 or response.status >= 300:
+        raise Exception(res)
+    else:
+        data = json.loads(res.decode('utf8'))
+        if not data:
+            raise Exception("Empty Response")
+        elif data.get('success'):
+            return data.get('result', [{}])
+        else:
+            raise Exception(data.get('errors', [{}]))
+
+
+def get_zone_id(domain):
+    """
+        切割域名获取主域名ID(Zone_ID)
+        https://api.cloudflare.com/#zone-list-zones
+    """
+    if len(domain.split('.')) > 2:
+        main = domain.split('.', 1)[1]
+    else:
+        main = domain
+    res = request('GET', '', name=main)
+    zoneid = res[0].get('id')
+    return zoneid
+
+
+def get_records(zoneid, **conditions):
+    """
+           获取记录ID
+           返回满足条件的所有记录[]
+           TODO 大于100翻页
+    """
+    if not hasattr(get_records, 'records'):
+        get_records.records = {}  # "静态变量"存储已查询过的id
+        get_records.keys = ('id', 'type', 'name', 'content', 'proxied', 'ttl')
+
+    if not zoneid in get_records.records:
+        get_records.records[zoneid] = {}
+        data = request('GET', '/' + zoneid + '/dns_records', per_page=100)
+        if data:
+            for record in data:
+                get_records.records[zoneid][record['id']] = {
+                    k: v for (k, v) in record.items() if k in get_records.keys}
+
+    records = {}
+    for (zid, record) in get_records.records[zoneid].items():
+        for (k, value) in conditions.items():
+            if record.get(k) != value:
+                break
+        else:  # for else push
+            records[zid] = record
+    return records
+
+
+def update_record(domain, value, record_type="A"):
+    """
+    更新记录
+    """
+    log.debug(">>>>>%s(%s)", domain, record_type)
+    zoneid = get_zone_id(domain)
+    if not zoneid:
+        raise Exception("invalid domain: [ %s ] " % domain)
+
+    records = get_records(zoneid, name=domain, type=record_type)
+    result = {}
+    if records:  # update
+        # https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
+        for (rid, record) in records.items():
+            if record['content'] != value:
+                res = request('PUT', '/' + zoneid + '/dns_records/' + record['id'],
+                              type=record_type, content=value, name=domain)
+                if res:
+                    get_records.records[zoneid][rid]['content'] = value
+                    result[rid] = res.get("record")
+                else:
+                    result[rid] = "Update fail!\n" + str(res)
+            else:
+                result[rid] = domain
+    else:  # create
+        # https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
+        res = request('POST', '/' + zoneid + '/dns_records',
+                      type=record_type, name=domain, content=value, proxied=False, ttl=600)
+        if res:
+            get_records.records[zoneid][res['id']] = res
+            get_records.records[zoneid][res['id']].update(
+                value=value, type=record_type)
+            result = res
+        else:
+            result = domain + " created fail!"
+    return result

--- a/run.py
+++ b/run.py
@@ -62,7 +62,9 @@ def get_ip(ip_type):
     get IP address
     """
     index = get_config('index' + ip_type) or "default"
-    if str(index).isdigit():  # local eth
+    if index == 'none':
+        return None
+    elif str(index).isdigit():  # local eth
         value = getattr(ip, "local_v" + ip_type)(index)
     elif any((c in index) for c in '*.:'):  # regex
         value = getattr(ip, "regex_v" + ip_type)(index)


### PR DESCRIPTION
添加CloudFlare支持，照葫芦画瓢写了一下（因为我个人是用CloudFlare的，之前自己写了一个很不优雅的DDNS程序（嗯现在还在我的仓库里，然后觉得大佬好厉害，所以就直接搬到这里来了23333

在config的index4/6中添加‘none’选项，这个是因为现在如果想要禁用ipv4或ipv6的解析更新，就必须把config中的ipv4/ipv6那项中的域名全部删除，否则就会报网络不可达错误。对于用户（其实是我23333）来说，一个禁用选项比删除掉所有域名更方便