### PR TITLE
fix ip regex in ip address format

### DIFF
--- a/util/ip.py
+++ b/util/ip.py
@@ -75,7 +75,7 @@ def regex_v4(reg):  # ipv4 正则提取
     if os_name == 'nt':  # Windows: IPv4 xxx: 192.168.1.2
         regex_str = r'IPv4 .*: ((?:\d{1,3}\.){3}\d{1,3})\W'
     else:
-        regex_str = r'inet (?:addr\:)?((?:\d{1,3}\.){3}\d{1,3})\s'
+        regex_str = r'inet (?:addr\:)?((?:\d{1,3}\.){3}\d{1,3})[\s/]'
     return ip_regex_match(regex_str, reg)
 
 
@@ -83,5 +83,5 @@ def regex_v6(reg):  # ipv6 正则提取
     if os_name == 'nt':  # Windows: IPv4 xxx: ::1
         regex_str = r'IPv6 .*: ([\:\dabcdef]*)?\W'
     else:
-        regex_str = r'inet6 (?:addr\:)?([\:\dabcdef]*)?\s'
+        regex_str = r'inet6 (?:addr\:)?([\:\dabcdef]*)?[\s/]'
     return ip_regex_match(regex_str, reg)

--- a/util/ip.py
+++ b/util/ip.py
@@ -63,7 +63,7 @@ def ip_regex_match(parrent_regex, match_regex):
     if os_name == 'nt':  # windows:
         cmd = 'ipconfig'
     else:
-        cmd = 'ifconfig || ip address'
+        cmd = 'ifconfig 2>/dev/null || ip address'
 
     for s in popen(cmd).readlines():
         addr = ip_pattern.search(s)
@@ -83,5 +83,5 @@ def regex_v6(reg):  # ipv6 正则提取
     if os_name == 'nt':  # Windows: IPv4 xxx: ::1
         regex_str = r'IPv6 .*: ([\:\dabcdef]*)?\W'
     else:
-        regex_str = r'inet6 (?:addr\:)?([\:\dabcdef]*)?[\s/]'
+        regex_str = r'inet6 (?:addr\:)?([\:\dabcdef]*)?[\s/%]'
     return ip_regex_match(regex_str, reg)


### PR DESCRIPTION
$ip address
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:15:5d:0f:87:07 brd ff:ff:ff:ff:ff:ff
    inet 30.57.177.145/24 brd 30.57.177.255 scope global noprefixroute dynamic eth0
       valid_lft 23131sec preferred_lft 23131sec
    inet6 fe80::65b6:1c2d:e0ff:f2bf/64 scope link noprefixroute
       valid_lft forever preferred_lft forever