### PR TITLE
修复dnspod在无子域名，如xx.com时无法更新之前的记录，而总是创建新的记录

### DIFF
--- a/dns/dnspod.py
+++ b/dns/dnspod.py
@@ -83,7 +83,8 @@ def get_domain_info(domain):
                 break
         else:
             warning('domain_id: %s, sub: %s', did, sub)
-            return None, None 
+            return None, None
+    sub = sub or '@'
     info('domain_id: %s, sub: %s', did, sub)
     return did, sub
 


### PR DESCRIPTION
因为dnspod返回的记录中使用@代表直接解析主域名　 {'id': '233', 'value': '3.1.1.1', 'enabled': '1', 'name': '@', 'line': '默认', 'line_id': '0', 'type': 'A', 'mx': '0'}