### PR TITLE
fix(ip): ip_public_api

### DIFF
--- a/util/ip.py
+++ b/util/ip.py
@@ -58,11 +58,11 @@ def _open(url, reg):
         error(e)
 
 
-def public_v4(url="https://pv.sohu.com/cityjson", reg=IPV4_REG):  # 公网IPV4地址
+def public_v4(url="https://pv.sohu.com/cityjson?ie=utf-8", reg=IPV4_REG):  # 公网IPV4地址
     return _open(url, reg)
 
 
-def public_v6(url="http://ipv6-test.com/api/myip.php", reg=IPV6_REG):  # 公网IPV6地址
+def public_v6(url="https://ipv6-test.com/api/myip.php", reg=IPV6_REG):  # 公网IPV6地址
     return _open(url, reg)
 
 


### PR DESCRIPTION
fix #130 #150 #155 #156 

此PR做了以下修改: 

1. 修改IPv4地址API。为目前的IPv4 API增加了ie=utf-8的属性，强制API以UTF-8返回数据，解决目前版本获取IPv4地址时因[ERROR] 'utf-8' codec can't decode byte 0xb1 in position 73: invalid start byte导致IPv4地址获取失败的Bug。

2. 修改IPv6地址API。考虑到目前的IPv6 API支持HTTPS，因此本PR将IPv6 API改为和IPv4 API相同的HTTPS方式请求，降低可能存在的安全风险。