### PR TITLE
feat(dnsapi): support custom dns api domain and update schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - 其他:
   - [x] 可设置定时任务
   - [x] TTL 配置支持
+  - [x] 自定义 API 域名配置
   - [x] 本地文件缓存(减少 API 请求)
 
 ## 使用
@@ -115,6 +116,7 @@ python run.py -c /path/to/config.json
 | index4 | string\|int |    No    | `"default"` |   ipv4 获取方式   | 可设置`网卡`,`内网`,`公网`,`正则`等方式                                                                     |
 | index6 | string\|int |    No    | `"default"` |   ipv6 获取方式   | 可设置`网卡`,`内网`,`公网`,`正则`等方式                                                                     |
 |  ttl   |   number    |    No    |   `null`    | DNS 解析 TTL 时间 | 不设置采用 DNS 默认策略                                                                                     |
+| dnsapi |   string    |    No    |     无      | 自定义 DNS API 域名| 表示默认 DNS API 域名，只支持运行在 443 端口且证书可被认可的 HTTPS 站点                                       |
 | proxy  |   string    |    No    |     无      | http 代理`;`分割  | 多代理逐个尝试直到成功,`DIRECT`为直连                                                                       |
 | debug  |    bool     |    No    |   `false`   |   是否开启调试    | 运行异常时,打开调试输出,方便诊断错误                                                                        |
 | cache  |    bool     |    No    |   `true`    |   是否缓存记录    | 正常情况打开避免频繁更新                                                                                    |
@@ -137,7 +139,7 @@ python run.py -c /path/to/config.json
 
 ```json
 {
-  "$schema": "https://ddns.newfuture.cc/schema/v2.8.json",
+  "$schema": "https://ddns.newfuture.cc/schema/v2.10.json",
   "id": "12345",
   "token": "mytokenkey",
   "dns": "dnspod 或 dnspod_com 或 alidns 或 dnscom 或 cloudflare 或 he 或 huaweidns",
@@ -146,6 +148,7 @@ python run.py -c /path/to/config.json
   "index4": 0,
   "index6": "public",
   "ttl": 600,
+  "dnsapi": "",
   "proxy": "127.0.0.1:1080;DIRECT",
   "debug": false
 }

--- a/run.py
+++ b/run.py
@@ -51,7 +51,7 @@ def get_config(key=None, default=None, path="config.json"):
             error(' Config file `%s` does not exist!' % path)
             with open(path, 'w') as configfile:
                 configure = {
-                    "$schema": "https://ddns.newfuture.cc/schema/v2.8.json",
+                    "$schema": "https://ddns.newfuture.cc/schema/v2.10.json",
                     "id": "YOUR ID or EAMIL for DNS Provider",
                     "token": "YOUR TOKEN or KEY for DNS Provider",
                     "dns": "dnspod",
@@ -66,6 +66,7 @@ def get_config(key=None, default=None, path="config.json"):
                     "index4": "default",
                     "index6": "default",
                     "ttl": None,
+                    "dnsapi": None,
                     "proxy": None,
                     "debug": False,
                 }
@@ -164,6 +165,8 @@ def main():
     dns.Config.ID = get_config('id')
     dns.Config.TOKEN = get_config('token')
     dns.Config.TTL = get_config('ttl')
+    if get_config('dnsapi'):
+        dns.API.SITE = get_config('dnsapi') # 支持自定义 DNS API 域名
     if get_config('debug'):
         ip.DEBUG = get_config('debug')
         basicConfig(

--- a/schema/v2.10.json
+++ b/schema/v2.10.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://ddns.newfuture.cc/schema/v2.10.json",
+  "description": "DNS 配置文件 https://github.com/NewFuture/DDNS",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "title": "please use https://ddns.newfuture.cc/schema/v2.10.json",
+      "description": "请更换为 https://ddns.newfuture.cc/schema/v2.10.json",
+      "default": "https://ddns.newfuture.cc/schema/v2.10.json",
+      "enum": [
+        "https://ddns.newfuture.cc/schema/v2.10.json",
+        "http://ddns.newfuture.cc/schema/v2.10.json",
+        "./schema/v2.10.json"
+      ]
+    },
+    "id": {
+      "$id": "/properties/id",
+      "type": [
+        "string",
+        "null"
+      ],
+      "title": "ID or Email",
+      "description": "DNS服务API认证的ID或者邮箱"
+    },
+    "token": {
+      "$id": "/properties/token",
+      "type": "string",
+      "title": "API Token",
+      "description": "DNS服务商的访问Token或者Key"
+    },
+    "dns": {
+      "$id": "/properties/dns",
+      "type": "string",
+      "title": "DNS Provider",
+      "description": "dns服务商:阿里为alidns,DNS.COM为dnscom,DNSPOD国际版为(dnspod_com),cloudflare,HE.net为he",
+      "default": "dnspod",
+      "examples": [
+        "dnspod",
+        "alidns",
+        "cloudflare"
+      ],
+      "enum": [
+        "dnspod",
+        "alidns",
+        "cloudflare",
+        "dnspod_com",
+        "dnscom",
+        "he",
+        "huaweidns"
+      ]
+    },
+    "ipv4": {
+      "$id": "/properties/ipv4",
+      "title": "IPv4 domain list",
+      "description": "待更新的IPv4 域名列表",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$id": "/properties/ipv4/items",
+        "title": "ipv4 domain for DDNS",
+        "type": "string",
+        "pattern": "^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,18}$",
+        "examples": [
+          "newfuture.cc",
+          "ipv4.example.newfuture.cc"
+        ]
+      }
+    },
+    "ipv6": {
+      "$id": "/properties/ipv6",
+      "type": "array",
+      "title": "IPv6 domain list",
+      "description": "待更新的IPv6 域名列表",
+      "uniqueItems": true,
+      "items": {
+        "$id": "/properties/ipv6/items",
+        "title": "The ipv6 domain for DDNS",
+        "type": "string",
+        "pattern": "^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,6}$",
+        "examples": [
+          "newfuture.cc",
+          "ipv6.example.newfuture.cc"
+        ]
+      }
+    },
+    "index4": {
+      "$id": "/properties/index4",
+      "type": [
+        "string",
+        "integer",
+        "boolean"
+      ],
+      "title": "IPv4 address Setting",
+      "description": "本机 IPv4 获取方式设置",
+      "default": "default",
+      "examples": [
+        "default",
+        "public",
+        0,
+        1,
+        "192\\\\.168\\\\..*",
+        false
+      ]
+    },
+    "index6": {
+      "$id": "/properties/index6",
+      "type": [
+        "string",
+        "integer",
+        "boolean"
+      ],
+      "title": "IPv6 address Setting",
+      "description": "本机 IPv6 获取方式设置",
+      "default": "default",
+      "examples": [
+        "default",
+        "public",
+        0,
+        1,
+        "2404:f801:10:.*",
+        false
+      ]
+    },
+    "ttl": {
+      "$id": "/properties/ttl",
+      "type": [
+        "number",
+        "null"
+      ],
+      "title": "TTL",
+      "description": "设置DNS TTL,默认不填读取DNS服务商的配置",
+      "default": null,
+      "examples": [
+        600,
+        null
+      ]
+    },
+    "dnsapi": {
+      "$id": "/properties/dnsapi",
+      "type": [
+        "string",
+        "null"
+      ],
+      "title": "Custom DNS API Domain",
+      "description": "表示默认 DNS API 域名，只支持运行在 443 端口且证书可被认可的 HTTPS 站点",
+      "pattern": "^[a-zA-Z0-9\\-_\\.]*$",
+      "examples": [
+        "cloudflare.example.newfuture.cc"
+      ]
+    },
+    "proxy": {
+      "$id": "/properties/proxy",
+      "type": [
+        "string",
+        "null"
+      ],
+      "title": "HTTP Proxy Setting",
+      "description": "DIRECT表示直连,多个代理分号(;)分割逐个尝试直到成功",
+      "pattern": "^[a-zA-Z0-9\\-;_:\\.]*$",
+      "examples": [
+        "127.0.0.1:1080;DIRECT"
+      ]
+    },
+    "debug": {
+      "$id": "/properties/debug",
+      "type": "boolean",
+      "title": "Enable Debug Mode",
+      "description": "是否启用调试模式显示更多信息",
+      "default": false,
+      "examples": [
+        false,
+        true
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "token"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
本PR新增了支持自定义 DNS API 域名的设置项，为空或省略此项表示默认 DNS API 域名。
DNS API 域名反代只支持运行在 443 端口且证书可被认可的 HTTPS 站点。

考虑到目前正在征集3.0版本设计，并且此修改包含1个API变更，不确定此时提交此PR是否合适。
并且对此项目和Python经验有限，不确定此修改方式和文案是否符合程序自身设计逻辑。
如此修改不符合要求，您可给出修改意见、关闭PR或直接修改，谢谢。

另：我这边测试过Cloudflare API，可以通过在Debian 10操作系统与Apache 2.4.38创建的反向代理站点更新DNS记录，其他API未测试。