### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY . .
 RUN pyinstaller --onefile --noconfirm --clean ./.build/ddns.spec
 
 FROM alpine:latest
+LABEL maintainer="NN708"
 COPY --from=0 /app/dist/ddns /
 RUN echo "*/5 * * * *   /ddns -c /config.json" > /etc/crontabs/root
 CMD [ "crond", "-f" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM six8/pyinstaller-alpine:latest
+WORKDIR /app
+COPY . .
+RUN pyinstaller --onefile --noconfirm --clean ./.build/ddns.spec
+
+FROM alpine:latest
+COPY --from=0 /app/dist/ddns /
+CMD [ "/ddns" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN pyinstaller --onefile --noconfirm --clean ./.build/ddns.spec
 
 FROM alpine:latest
 COPY --from=0 /app/dist/ddns /
-CMD [ "/ddns" ]
+RUN echo "*/5 * * * *   /ddns -c /config.json" > /etc/crontabs/root
+CMD [ "crond", "-f" ]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 - #### 二进制版(单文件,无需 python)
   - Windows [ddns.exe](https://github.com/NewFuture/DDNS/releases/latest)
   - Linux (仅 Ubuntu 测试) [ddns](https://github.com/NewFuture/DDNS/releases/latest)
-  - Mac OSX [ddns-oxs](https://github.com/NewFuture/DDNS/releases/latest)
+  - Mac OSX [ddns-osx](https://github.com/NewFuture/DDNS/releases/latest)
 - #### 源码运行(无任何依赖, 需 python 环境)
   1. clone 或者[下载此仓库](https://github.com/NewFuture/DDNS/archive/master.zip)并解压
   2. 运行./run.py (widnows 双击`run.bat`或者运行`python run.py`)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 ### ① 安装
 
-根据需要选择一种方式: `二进制`版,`pip`版,或者`源码`运行
+根据需要选择一种方式: `二进制`版,`pip`版,`源码`运行,或者`Docker`
 
 - #### pip 安装(需要 pip 或 easy_install)
   1. 安装 ddns: `pip install ddns` 或 `easy_install ddns`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [x] 多系统兼容 ![cross platform](https://img.shields.io/badge/platform-windows_%7C%20linux_%7C%20osx-success.svg?style=social)
   - [x] python2 和 python3 支持 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ddns.svg?style=social)
   - [x] PIP 安装 ![PyPI - Wheel](https://img.shields.io/pypi/wheel/ddns.svg?style=social)
+  - [x] Docker 支持(@NN708)
 - 域名支持:
   - [x] 多个域名支持
   - [x] 多级域名解析
@@ -72,6 +73,8 @@
 - #### 源码运行(无任何依赖, 需 python 环境)
   1. clone 或者[下载此仓库](https://github.com/NewFuture/DDNS/archive/master.zip)并解压
   2. 运行./run.py (widnows 双击`run.bat`或者运行`python run.py`)
+- #### Docker(需要安装 Docker)
+  `docker run -d -v /path/to/config.json:/config.json --network host newfuture/ddns`
 
 ### ② 快速配置
 


### PR DESCRIPTION
解决 issue #182 和 #40。

基于 Alpine 的最小 Docker 容器，采用两步构建，使用 six8/pyinstaller-alpine 编译为二进制文件后执行，支持 cron 的计划任务。

后续可以考虑上传至 Docker Hub。