### PR TITLE
ci: Add GitHub Actions for Docker buildx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  docker-buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+      - name: Prepare arguments
+        id: prepare
+        env:
+          DOCKER_REPO: newfuture/ddns
+          DOCKER_PLATFORMS: linux/amd64,linux/arm,linux/arm64
+        run: |
+          DOCKER_PUSH=false
+          DOCKER_TAGS="--tag ${DOCKER_REPO}:latest"
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            DOCKER_PUSH=true
+            DOCKER_TAGS="${DOCKER_TAGS} --tag ${DOCKER_REPO}:${GITHUB_REF#refs/tags/v}"
+          fi
+          echo ::set-output name=buildx_push::${DOCKER_PUSH}
+          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} ${DOCKER_TAGS} .
+      - name: Run buildx
+        run: |
+          docker buildx build \
+            --output "type=image,push=false" \
+            ${{ steps.prepare.outputs.buildx_args }}
+      - name: Docker Hub login
+        if: success() && steps.prepare.outputs.buildx_push == 'true'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login \
+            --username "${DOCKER_USERNAME}" \
+            --password-stdin
+      - name: Run buildx and push
+        if: success() && steps.prepare.outputs.buildx_push == 'true'
+        run: |
+          docker buildx build \
+            --output "type=image,push=true" \
+            ${{ steps.prepare.outputs.buildx_args }}
+      - name: Docker Hub logout
+        if: always() && steps.prepare.outputs.buildx_push == 'true'
+        run: docker logout


### PR DESCRIPTION
尝试使用 GitHub Actions 自动构建多架构的 Docker image。目前的策略是对 master 分支的 push 和 pull request 运行构建进行检查，对版本号 tag 运行构建并推送到 Docker Hub（同时更新 latest）。在推送之前需要在 Settings -> Secrets 中设置 DOCKER_USERNAME 和 DOCKER_PASSWORD 环境变量。