### PR TITLE
Add single quotes in case the paths have spaces

### DIFF
--- a/.release/create-task.bat
+++ b/.release/create-task.bat
@@ -1,12 +1,12 @@
 @ECHO OFF
 REM https://msdn.microsoft.com/zh-cn/library/windows/desktop/bb736357(v=vs.85).aspx
 
-SET RUNCMD="%~dp0ddns.exe" -c "%~dp0config.json" >> "%~dp0run.log"
+SET RUNCMD="'%~dp0ddns.exe' -c '%~dp0config.json' >> '%~dp0run.log'"
 
 SET RUN_USER=%USERNAME%
 WHOAMI /GROUPS | FIND "12288" > NUL && SET RUN_USER="SYSTEM"
 
 ECHO Create task run as %RUN_USER%
-schtasks /Create /SC MINUTE /MO 5 /TR "%RUNCMD%" /TN "DDNS" /F /RU "%RUN_USER%"
+schtasks /Create /SC MINUTE /MO 5 /TR %RUNCMD% /TN "DDNS" /F /RU "%RUN_USER%"
 
 PAUSE


### PR DESCRIPTION
The script will run failed when the paths have spaces such as 'C:\Program Files\DDNS\ddns.exe'.
One possible solution is to add single quotes to each path.
Ref. https://stackoverflow.com/questions/10542313/powershell-and-schtask-with-task-that-has-a-space