### PR TITLE
Change ddns.exe to cmd in Windows Task Scheduler.

### DIFF
--- a/.release/create-task.bat
+++ b/.release/create-task.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 REM https://msdn.microsoft.com/zh-cn/library/windows/desktop/bb736357(v=vs.85).aspx
 
-SET RUNCMD="'%~dp0ddns.exe' -c '%~dp0config.json' >> '%~dp0run.log'"
+SET RUNCMD="cmd /c ''%~dp0ddns.exe' -c '%~dp0config.json' >> '%~dp0run.log''"
 
 SET RUN_USER=%USERNAME%
 WHOAMI /GROUPS | FIND "12288" > NUL && SET RUN_USER="SYSTEM"


### PR DESCRIPTION
Windows Task Scheduler is not CMD, the redirecting operator '>>' can only effect in CMD. So the operator will cause '0x2' error in Windows Task Scheduler.
My last commit https://github.com/NewFuture/DDNS/pull/208/commits/8ea0d5976de4a668e973e19548c8f2315f7b930f will force add the redirecting to the Win TS due to the double quotes in ```RUNCMD```, while the previous commit did not add log redirecting to Win TS as expected(Fig) and the log file was always empty.
![image](https://user-images.githubusercontent.com/16972222/96025770-2e4be900-0e88-11eb-835d-0e4a612947c7.png)

One solution in this commit is to change the running program in Win TS from ddns.exe to cmd, then run ddns.exe in cmd. So that the Task can run as scheduled and the log can also be redirected.
![image](https://user-images.githubusercontent.com/16972222/96025990-8387fa80-0e88-11eb-8142-4f3c5987c5d8.png)
