### PR TITLE
更改dockerfile中的corn表达式错误

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN pyinstaller --onefile --noconfirm --clean ./.build/ddns.spec
 FROM alpine:latest
 LABEL maintainer="NN708"
 COPY --from=0 /app/dist/ddns /
-RUN echo "*/5 * * * *   /ddns -c /config.json" > /etc/crontabs/root
+RUN echo "0/5 * * * *   /ddns -c /config.json" > /etc/crontabs/root
 CMD [ "crond", "-f" ]


### PR DESCRIPTION
经测试发现原corn表达式在该image中无法执行 故更改corn表达式