### PR TITLE
Fix shebang typo

### DIFF
--- a/systemd.sh
+++ b/systemd.sh
@@ -1,4 +1,4 @@
-# /bin/bash
+#!/bin/bash
 service='[Unit]
 Description=NewFuture ddns
 After=network.target


### PR DESCRIPTION
Current shebang for `systemd.sh` has a syntax problem, which causes `[[` (string compare) could not work under `sh` shell environment. 