### PR TITLE
fix regex_v6 string

### DIFF
--- a/util/ip.py
+++ b/util/ip.py
@@ -94,5 +94,5 @@ def regex_v6(reg):  # ipv6 正则提取
     if os_name == 'nt':  # Windows: IPv4 xxx: ::1
         regex_str = r'IPv6 .*: ([\:\dabcdef]*)?\W'
     else:
-        regex_str = r'inet6 (?:addr\:)?([\:\dabcdef]*)?[\s/%]'
+        regex_str = r'inet6 (?:addr\:\s*)?([\:\dabcdef]*)?[\s/%]'
     return _ip_regex_match(regex_str, reg)


### PR DESCRIPTION
example:
          inet6 addr: fe80::f471:b5ff:fea0:2687/64 Scope:Link