### PR TITLE
update dnspod.py for request length

### DIFF
--- a/dns/dnspod.py
+++ b/dns/dnspod.py
@@ -34,6 +34,7 @@ class API:
     METHOD = "POST"  # 请求方法
     TOKEN_PARAM = "login_token"  # token参数
     DEFAULT = "默认"  # 默认线路名
+    LENGTH="length" #添加参数
 
 
 def request(action, param=None, **params):
@@ -46,6 +47,7 @@ def request(action, param=None, **params):
     params.update({API.TOKEN_PARAM: '***', 'format': 'json'})
     info("%s/%s : %s", API.SITE, action, params)
     params[API.TOKEN_PARAM] = "%s,%s" % (Config.ID, Config.TOKEN)
+    params[API.LENGTH] = "3000" #添加参数
     if Config.PROXY:
         conn = HTTPSConnection(Config.PROXY)
         conn.set_tunnel(API.SITE, 443)


### PR DESCRIPTION
Modify default request length for dnspod to 3000
Detail:
https://github.com/NewFuture/DDNS/issues/270#issuecomment-876920589