### PR TITLE
fix(ip.py): ignore non-utf format encoding

### DIFF
--- a/util/ip.py
+++ b/util/ip.py
@@ -51,7 +51,7 @@ def _open(url, reg):
         debug("open: %s", url)
         res = urlopen(
             Request(url, headers={'User-Agent': 'curl/7.63.0-ddns'}),  timeout=60
-        ).read().decode('utf8')
+        ).read().decode('utf8', 'ignore')
         debug("response: %s",  res)
         return compile(reg).search(res).group()
     except Exception as e:


### PR DESCRIPTION
Some websites that display IP use non-utf encoding like gbk encoding, which leads to errors when the script is decoding content from these websites. Those non-utf encoding characters like Chinese characters do not affect our job because we just want to match the IP address in the decoded text, so we can ignore those non-utf encoding characters.

有些显IP网站包含非utf编码字符，会导致脚本在decode的时候因为无法以utf解码而出错。而那些导致出错的中文字符不会影响IP的匹配，所以可以在解码时忽略。