### PR TITLE
run.py: Add powershell support for ddns-ipv4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,34 @@ python run.py -c /path/to/config.json
 }
 ```
 
+dnspod + PowerShell 配置示例：
+
+```json
+{
+  "$schema": "https://ddns.newfuture.cc/schema/v2.8.json",
+  "debug": false,
+  "dns": "dnspod",
+  "id": "2xxxx4",
+  "index4": "powershell:",
+  "index6": "",
+  "ipv4": [
+    "abc.test.cn"
+  ],
+  "ipv6": [
+  ],
+  "proxy": null,
+  "token": "xxx",
+  "ttl": null
+}
+```
+
+```powershell
+# Replace Ehternet_UCAS with the <InterfaceAlias> of your target interface.
+#                                      ↓
+(Get-NetIPAddress -InterfaceAlias Ethernet_UCAS -AddressFamily IPv4).IPAddress
+
+```
+
 </details>
 
 ## 定时任务

--- a/get-ipv4.ps1
+++ b/get-ipv4.ps1
@@ -1,0 +1,3 @@
+# Replace Ehternet_UCAS with the <InterfaceAlias> of your target interface.
+# 				  ↓
+(Get-NetIPAddress -InterfaceAlias Ethernet_UCAS -AddressFamily IPv4).IPAddress

--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ from os import path, environ, name as os_name
 from tempfile import gettempdir
 from logging import DEBUG, basicConfig, info, warning, error, debug
 from subprocess import check_output
+from subprocess import run
 
 import sys
 
@@ -56,6 +57,8 @@ def get_ip(ip_type, index="default"):
     elif index.startswith('shell:'):  # shell
         value = str(check_output(
             index[6:], shell=True).strip().decode('utf-8'))
+    elif index.startswith('powershell:'):  # powershell
+        value = run("powershell.exe -ExecutionPolicy RemoteSigned -file get-ipv4.ps1", capture_output=True).stdout.decode('utf-8')[:-2]
     elif index.startswith('url:'):  # 自定义 url
         value = getattr(ip, "public_v" + ip_type)(index[4:])
     elif index.startswith('regex:'):  # 正则 regex


### PR DESCRIPTION
With Python 3.10, `run.py` now supports PowerShell for index4.

You need to configure the `get-ipv4.ps1` PowerShell script manually. Fortunately, it is very simple.

It has been tested on my PC.

I don't know what I should do with the continuous integrated procedure.