### PR TITLE
feat(run): support custom cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ python run.py -c /path/to/config.json
 |  ttl   |       number       |    No    |   `null`    | DNS 解析 TTL 时间 | 不设置采用 DNS 默认策略                                                                                     |
 | proxy  |       string       |    No    |     无      | http 代理`;`分割  | 多代理逐个尝试直到成功,`DIRECT`为直连                                                                       |
 | debug  |        bool        |    No    |   `false`   |   是否开启调试    | 运行异常时,打开调试输出,方便诊断错误                                                                        |
-| cache  |    string\|bool    |    No    |   `true`    |   是否缓存记录    | 正常情况打开避免频繁更新,默认位置为临时目录下`ddns.cache`,<br>也可以指定一个具体文件实现自定义文件缓存位置                                                                                    |
+| cache  |    string\|bool    |    No    |   `true`    |   是否缓存记录    | 正常情况打开避免频繁更新,默认位置为临时目录下`ddns.cache`,<br>也可以指定一个具体文件实现自定义文件缓存位置         |
 
 #### index4 和 index6 参数说明
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ python run.py -c /path/to/config.json
 |  ttl   |       number       |    No    |   `null`    | DNS 解析 TTL 时间 | 不设置采用 DNS 默认策略                                                                                     |
 | proxy  |       string       |    No    |     无      | http 代理`;`分割  | 多代理逐个尝试直到成功,`DIRECT`为直连                                                                       |
 | debug  |        bool        |    No    |   `false`   |   是否开启调试    | 运行异常时,打开调试输出,方便诊断错误                                                                        |
-| cache  |        bool        |    No    |   `true`    |   是否缓存记录    | 正常情况打开避免频繁更新                                                                                    |
+| cache  |    string\|bool    |    No    |   `true`    |   是否缓存记录    | 正常情况打开避免频繁更新,默认位置为临时目录下`ddns.cache`,<br>也可以指定一个具体文件实现自定义文件缓存位置                                                                                    |
 
 #### index4 和 index6 参数说明
 

--- a/run.py
+++ b/run.py
@@ -34,9 +34,6 @@ if getattr(sys, 'frozen', False):
     environ['SSL_CERT_FILE'] = path.join(
         getattr(sys, '_MEIPASS'), 'lib', 'cert.pem')
 
-CACHE_FILE = path.join(gettempdir(), 'ddns.cache')
-
-
 def get_ip(ip_type, index="default"):
     """
     get IP address
@@ -139,7 +136,9 @@ def main():
     proxy_list = proxy if isinstance(
         proxy, list) else proxy.strip('; ').replace(',', ';').split(';')
 
-    cache = get_config('cache', True) and Cache(CACHE_FILE)
+    cache = get_config('cache', True)
+    cache = cache is True ? path.join(gettempdir(), 'ddns.cache') : cache;
+    cache = Cache(cache)
     if cache is False:
         info("Cache is disabled!")
     elif get_config("config_modified_time") is None or get_config("config_modified_time") >= cache.time:

--- a/run.py
+++ b/run.py
@@ -34,6 +34,7 @@ if getattr(sys, 'frozen', False):
     environ['SSL_CERT_FILE'] = path.join(
         getattr(sys, '_MEIPASS'), 'lib', 'cert.pem')
 
+
 def get_ip(ip_type, index="default"):
     """
     get IP address
@@ -137,7 +138,7 @@ def main():
         proxy, list) else proxy.strip('; ').replace(',', ';').split(';')
 
     cache = get_config('cache', True)
-    cache = cache is True and path.join(gettempdir(), 'ddns.cache') or cache;
+    cache = cache is True and path.join(gettempdir(), 'ddns.cache') or cache
     cache = Cache(cache)
     if cache is False:
         info("Cache is disabled!")

--- a/run.py
+++ b/run.py
@@ -137,7 +137,7 @@ def main():
         proxy, list) else proxy.strip('; ').replace(',', ';').split(';')
 
     cache = get_config('cache', True)
-    cache = cache is True ? path.join(gettempdir(), 'ddns.cache') : cache;
+    cache = cache is True and path.join(gettempdir(), 'ddns.cache') or cache;
     cache = Cache(cache)
     if cache is False:
         info("Cache is disabled!")

--- a/schema/v2.8.json
+++ b/schema/v2.8.json
@@ -186,13 +186,17 @@
     },
     "cache": {
       "$id": "/properties/cache",
-      "type": "boolean",
+      "type": [
+        "string",
+        "boolean"
+      ],
       "title": "Enable Cache",
       "description": "是否启用缓存记录以避免频繁更新",
       "default": true,
       "examples": [
         true,
-        false
+        false,
+        "/path/to/cache/ddns.cache"
       ]
     }
   },


### PR DESCRIPTION
根据 #143 提出的需求，本 PR 新增了自定义 DDNS 缓存文件的功能。
此处参考其他字段设计将 cache 字段更改为多类型字段，从而实现同一个字段既可以开关缓存又可以指定特定文件存放位置的功能。