### PR TITLE
修复cache为False时的崩溃问题

### DIFF
--- a/run.py
+++ b/run.py
@@ -137,15 +137,20 @@ def main():
     proxy_list = proxy if isinstance(
         proxy, list) else proxy.strip('; ').replace(',', ';').split(';')
 
-    cache = get_config('cache', True)
-    cache = cache is True and path.join(gettempdir(), 'ddns.cache') or cache
-    cache = Cache(cache)
+    cache_config = get_config('cache', True)
+    if cache_config is False:
+        cache = cache_config
+    elif cache_config is True:
+        cache = Cache(path.join(gettempdir(), 'ddns.cache'))
+    else:
+        cache = Cache(cache_config)
+
     if cache is False:
         info("Cache is disabled!")
     elif get_config("config_modified_time") is None or get_config("config_modified_time") >= cache.time:
         warning("Cache file is out of dated.")
         cache.clear()
-    elif not cache:
+    else:
         debug("Cache is empty.")
     update_ip('4', cache, dns, proxy_list)
     update_ip('6', cache, dns, proxy_list)


### PR DESCRIPTION
原先代码存在逻辑问题，在cache配置为False情况下仍然创建了Cache结构体，导致认为创建出的Cache对象是合法对象，析构时open(False)抛出异常。

崩溃栈回溯如下，意思是调用了析构函数 `__del__` 时触发崩溃：

```
Exception ignored in: <function Cache.__del__ at 0x0000022A7420F160>
Traceback (most recent call last):
  File "D:\python\python38\lib\site-packages\util\cache.py", line 140, in __del__
    self.close()
  File "D:\python\python38\lib\site-packages\util\cache.py", line 95, in close
    self.sync()
  File "D:\python\python38\lib\site-packages\util\cache.py", line 83, in sync
    with open(self.__filename, 'wb') as data:
ValueError: Cannot open console input buffer for writing
```

跟踪代码，如果140行的cache是False，则142行的对象仍然被创建，因此144行的分支永远不可达。
```python
140    cache = get_config('cache', True)
141    cache = cache is True and path.join(gettempdir(), 'ddns.cache') or cache
142    cache = Cache(cache)
143    if cache is False:
144        info("Cache is disabled!")
```
因此这里存在逻辑问题，已通过重构代码的方式修复。