### PR TITLE
修复windows下定时任务输出

### DIFF
--- a/task.bat
+++ b/task.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 REM https://msdn.microsoft.com/zh-cn/library/windows/desktop/bb736357(v=vs.85).aspx
 
-SET RUNCMD=python "%~dp0run.py" -c "%~dp0config.json" >> "%~dp0run.log"
+SET RUNCMD="%~dp0run.bat" "%~dp0run.log"
 
 SET RUN_USER=%USERNAME%
 WHOAMI /GROUPS | FIND "12288" > NUL && SET RUN_USER="SYSTEM"


### PR DESCRIPTION
BUG自 https://github.com/NewFuture/DDNS/commit/339e58b6121ef52cc5134a576b0a680ec2a1142a 引入

schtasks 的 `/TR "%RUNCMD%"`里，RUNCMD是 executable arg0 arg1的格式，无法处理重定向符，executable arg0 arg1 >> output.txt，不会在文件末尾追加标准输出，疑似将 ">>" 视为了入参。

且此处疑似存在由 ">>" 引起的转义问题，对commit进行回滚，消除BUG。