### PR TITLE
希望能更改linux系统下，index6 正则获取本地ip的命令优先级

### DIFF
--- a/util/ip.py
+++ b/util/ip.py
@@ -74,7 +74,7 @@ def _ip_regex_match(parrent_regex, match_regex):
     if os_name == 'nt':  # windows:
         cmd = 'ipconfig'
     else:
-        cmd = 'ifconfig 2>/dev/null || ip address'
+        cmd = 'ip address || ifconfig 2>/dev/null'
 
     for s in popen(cmd).readlines():
         addr = ip_pattern.search(s)


### PR DESCRIPTION
优先使用ip address 而非ifconfig，理由如下：
ifconfig 会先匹配到处于弃用（Deprecated）状态的v6 ip，不会把处于弃用的v6放到末尾，导致提交的dns v6解析记录为过期v6 ip。
![20240627041149](https://github.com/NewFuture/DDNS/assets/56445378/5c1e896f-1e34-4831-aad2-aef8a3f96e6e)

而ip address获取到的前两个ip均为有效前缀v6 ip，可能是对lifetime 或者 ip 获得时间进行过排序
![20240627041324](https://github.com/NewFuture/DDNS/assets/56445378/4d0a7c9e-947d-49a6-b5eb-e0f55d17f9dd)

ipaddr 与 win 系统下的ipconfig ip顺序一致，符合“排序”期望
![20240627041440](https://github.com/NewFuture/DDNS/assets/56445378/e2ecbcc6-390d-430c-8da8-feabb8310285)

故希望在linux系统中，优先考虑使用ipaddress 而非 ifconfig