### PR TITLE
针对 `docker` 的一些优化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ RUN pyinstaller --onefile --noconfirm --clean ./.build/ddns.spec
 
 FROM alpine:latest
 LABEL maintainer="NN708"
+
 COPY --from=0 /app/entrypoint.sh /
 COPY --from=0 /app/dist/ddns /
+
+RUN ln -s /ddns /usr/bin/ddns
+
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,23 @@
       --network host \
       newfuture/ddns
     ```
+  - 使用配置文件夹：
+    ```
+    docker run -d \
+      -v /path/to/config/:/config/ \
+      --network host \
+      newfuture/ddns
+    ```
 
+- #### Docker Compose (需要安装 Docker, docker-compose)
+    ```
+    mkdir /tmp/ddns
+    cd /tmp/ddns
+    wget https://github.com/NewFuture/DDNS/raw/refs/heads/master/docker-compose.yaml
+    vi / vim / nano docker-compose.yaml
+    docker compose up -d
+    docker compose exec -ti command_run -h
+    ```
 ### ② 快速配置
 
 1. 申请 api `token`,填写到对应的`id`和`token`字段:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,70 @@
+# This is a sample docker-compose file for the ddns service
+# It includes different ways to configure the service:
+# 1. Using a config file
+# 2. Using a config directory
+# 3. Using environment variables
+# 4. Using an env file
+# 5. Using command line arguments
+# 6. Using a config file with a custom path
+
+
+services:
+    config_file:
+        image: newfuture/ddns
+        network_mode: host
+        environment:
+            - TZ=Asia/Shanghai
+        volumes:
+            - /path/to/config.json:/config.json
+        restart: unless-stopped
+
+    config_dir:
+        image: newfuture/ddns
+        network_mode: host
+        environment:
+            - TZ=Asia/Shanghai
+        volumes:
+            - /path/to/config/:/config/
+        restart: unless-stopped
+
+    environment_run:
+        image: newfuture/ddns
+        network_mode: host
+        environment:
+            - TZ=Asia/Shanghai
+            - DDNS_DNS=dnspod
+            - DDNS_ID=12345
+            - DDNS_TOKEN=mytokenkey
+            - DDNS_IPV4=ddns.newfuture.cc
+            - DDNS_IPV6=ddns.newfuture.cc
+        restart: unless-stopped
+
+    environment_file:
+        image: newfuture/ddns
+        network_mode: host
+        env_file:
+            - /path/to/envfile.env
+        environment:
+            - TZ=${TZ}
+        restart: unless-stopped
+
+    command_run:
+        image: newfuture/ddns
+        network_mode: host
+        command: >
+            --dns=dnspod 
+            --id=12345
+            --token=mytokenkey
+            --ipv4=ddns.newfuture.cc 
+            --ipv6=ddns.newfuture.cc
+        restart: unless-stopped
+
+    config_file_custom_path:
+        image: newfuture/ddns
+        network_mode: host
+        environment:
+            - TZ=Asia/Shanghai
+        volumes:
+            - /path/to/config.json:/custom/path/config.json
+        command: --config=/custom/path/config.json
+        restart: unless-stopped

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,62 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
+# CN: 该脚本用于在容器启动时执行 ddns 命令, 并创建定时任务
+# EN: This script is used to execute the ddns command when the container starts and create a scheduled task
+
+# CN: 如果没有传入参数
+# EN: If no parameters are passed in
 if [ $# -eq 0 ]; then
-  printenv > /etc/environment
-  echo "*/5 * * * *   /ddns -c /config.json" > /etc/crontabs/root
-  exec crond -f
+    printenv > /etc/environment
+
+    ### CONF FILE OR ENV ###
+    # CN: 不存在 /config 文件夹，则执行
+    # EN: If the /config folder does not exist, execute
+    if [ ! -d /config ]; then
+        # CN: 不存在 /config.json 文件,则执行 /ddns
+        # EN: If the /config.json file does not exist, execute /ddns
+        if [ ! -f /config.json ]; then
+            exec /ddns
+        fi
+        exec /ddns -c /config.json
+        echo "*/5 * * * *   /ddns -c /config.json" > /etc/crontabs/root
+        exec crond -f
+    fi
+    ### CONF FILE OR ENV ###
+
+    ### CONF PATH        ###
+    # CN: 存在 /config 文件夹,则遍历 /config 文件夹下的json文件,依次执行 /ddns -c /config/xxx.json
+    # EN: If the /config folder exists, traverse the json file under the /config folder, and execute /ddns -c /config/xxx.json
+    if [ -d /config ]; then
+      cat >/tmp/run.sh << 'END_OF_SCRIPT'
+#!/usr/bin/env sh
+# CN: 遍历 /config 文件夹下的json文件,依次执行 /ddns -c /config/xxx.json
+# EN: Traverse the json file under the /config folder, and execute /ddns -c /config/xxx.json
+for file in /config/*.json
+do
+    /ddns -c $file
+done
+END_OF_SCRIPT
+        chmod +x /tmp/run.sh
+        # CN: 执行 /tmp/run.sh
+        # EN: Execute /tmp/run.sh
+        /tmp/run.sh
+        echo "*/5 * * * *   /tmp/run.sh" > /etc/crontabs/root
+        exec crond -f
+    fi
+    ### CONF PATH        ###
+
 else
-  first=`echo $1 | cut -c1`
-  if [ "$first" = "-" ]; then
-    exec /ddns $@
-  else
-    exec $@
-  fi
+
+    first=`echo $1 | cut -c1`
+    if [ "$first" = "-" ]; then
+        exec /ddns $@
+        # CN: 创建定时任务
+        # EN: Create a scheduled task
+        echo "*/5 * * * *   /ddns $@" > /etc/crontabs/root
+        # CN: 执行定时任务
+        # EN: Execute the scheduled task
+        exec crond -f
+    else
+        exec $@
+    fi
 fi


### PR DESCRIPTION

 在容器启动时执行一次更新操作
 最好把 ddns 放在 $PATH 目录下面 方便调用
  自定义配置文件路径也可以定时了，方便映射一个目录到容器内
  丢一堆配置文件到文件夹，遍历 json  文件执行
  docker-compsoe 示例

实现 closes #451  #450 