### PR TITLE
fix(run): remove legacy regex support and fix lint

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           images: |
             ghcr.io/newfuture/ddns
             newfuture/ddns
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm,linux/arm64

--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ python run.py -c /path/to/config.json
 - 字符串`"public"`: 使用公网 ip(使用公网 API 查询,url 的简化模式)
 - 字符串`"url:xxx"`: 打开 URL `xxx`(如:`"url:http://ip.sb"`),从返回的数据提取 IP 地址
 - 字符串`"regex:xxx"` 正则表达(如`"regex:192.*"`): 提取`ifconfig`/`ipconfig`中与之匹配的首个 IP 地址,**注意 json 转义**(`\`要写成`\\`)
-  - `"192.*"`表示 192 开头的所有 ip
-  - 如果想匹配`10.00.xxxx`应该写成`"regex:10\\.00\\..\*"`(`"\\"`json 转义成`\`)
+  - `"192.*"`表示 192 开头的所有 ip (注意`regex:`不可省略)
+  - 如果想匹配`10.00.xxxx`应该写成`"regex:10\\.00\\..*"` (`"\\"` json 转义成`\`)
 - 字符串`"cmd:xxxx"`: 执行命令`xxxx`的 stdout 输出结果作为目标 IP
 - 字符串`"shell:xxx"`: 使用系统 shell 运行`xxx`,并把结果 stdout 作为目标 IP
 - `false`: 强制禁止更新 ipv4 或 ipv6 的 DNS 解析
 - 列表：依次执行列表中的index规则，并将最先获得的结果作为目标 IP
-  - 例如`["public", "172.*"]`将先查询公网API，未获取到IP后再从本地寻找172开头的IP
+  - 例如`["public", "regex:172\\..*"]`将先查询公网API，未获取到IP后再从本地寻找172开头的IP
 
 #### 自定义回调配置说明
 

--- a/run.py
+++ b/run.py
@@ -62,14 +62,13 @@ def get_ip(ip_type, index="default"):
             value = getattr(ip, "public_v" + ip_type)(index[4:])
         elif index.startswith('regex:'):  # 正则 regex
             value = getattr(ip, "regex_v" + ip_type)(index[6:])
-        elif any((c in index) for c in '*.:'):  # 兼容 regex
-            value = getattr(ip, "regex_v" + ip_type)(index)
         else:
             value = getattr(ip, index + "_v" + ip_type)()
     except Exception as e:
         error(e)
     finally:
         return value
+
 
 def change_dns_record(dns, proxy_list, **kw):
     for proxy in proxy_list:


### PR DESCRIPTION
BREAKING CHANGE:  regex must be start with `regex:` now