### PR TITLE
fix(docker): compatibility of old default config path

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,18 @@
 
 if [ $# -eq 0 ]; then
   printenv > /etc/environment
+  if [ -f /config.json ]; then
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    if [ ! -f /ddns/config.json ]; then
+      ln -s /config.json /ddns/config.json
+      echo "WARNING: /ddns/config.json not found. Created symlink to /config.json."
+    fi
+     echo "WARNING: From v4.0.0, the working dir is /ddns/"
+     echo "WARNING: Please map your host folder to /ddns/"
+     echo "[old] -v /host/folder/config.json:/config.json"
+     echo "[new] -v /host/folder/:/ddns/"
+     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  fi
   echo "*/5 * * * *  cd /ddns && /bin/ddns" > /etc/crontabs/root
   /bin/ddns &&  echo "Cron daemon will run every 5 minutes..." && exec crond -f
 else


### PR DESCRIPTION
兼容旧版本docker默认配置文件路径 并警告

resolve #486