### PR TITLE
Refact(tests): improve base ,test,  and instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,81 @@
+This is a Python-based Dynamic DNS (DDNS) client that automatically updates DNS records to match the current IP address. It supports multiple DNS providers, IPv4/IPv6, and various configuration methods. Please follow these guidelines when contributing:
+
+## Code Standards
+
+### Required Before Each Commit
+- Follow Python coding standards as defined in `.github/instructions/python.instructions.md`
+- Use only Python standard library modules (no external dependencies)
+- Ensure Python 2.7 and 3.x compatibility
+- Run tests before committing to ensure all functionality works correctly
+
+### Development Flow
+- Test: `python -m unittest discover tests` or `python -m pytest tests/`
+- Format: Use black and flake8 for code formatting
+
+### Add a New DNS Provider
+
+Follow the steps below to add a new DNS provider:
+- [Python coding standards](./instructions/python.instructions.md)
+- [Provider development guide](../doc/dev/provider.md)
+
+## Repository Structure
+- `ddns/`: Main application code
+  - `provider/`: DNS provider implementations (DNSPod, AliDNS, CloudFlare, etc.)
+  - `util/`: Utility functions (HTTP client, configuration management, IP detection)
+- `tests/`: Unit tests using unittest framework
+- `doc/`: Documentation and user guides
+  - `providers/`: Provider-specific configuration guides
+  - `dev/`: Developer documentation
+- `schema/`: JSON configuration schemas
+- `docker/`: Docker-related files and scripts
+
+## Key Guidelines
+1. Follow Python best practices and maintain cross-platform compatibility
+2. Use only standard library modules to ensure self-contained operation
+3. Maintain Python 2.7 compatibility (avoid f-strings, async/await)
+4. Write comprehensive unit tests for all new functionality
+5. Use proper logging and error handling throughout the codebase
+6. Document public APIs and configuration options thoroughly
+7. Test provider implementations against real APIs when possible
+8. Ensure all DNS provider classes inherit from BaseProvider or SimpleProvider
+
+## Testing Guidelines
+
+### Test Structure
+- Place tests in `tests/` directory using `test_*.py` naming
+- Inherit from `BaseProviderTestCase` for consistency
+- Use unittest (default) or pytest (optional)
+
+### Basic Test Template
+```python
+from base_test import BaseProviderTestCase, patch, MagicMock
+from ddns.provider.example import ExampleProvider
+
+class TestExampleProvider(BaseProviderTestCase):
+    def setUp(self):
+        super(TestExampleProvider, self).setUp()
+        self.provider = ExampleProvider(self.auth_id, self.auth_token)
+    
+    @patch.object(ExampleProvider, "_http")
+    def test_set_record_success(self, mock_http):
+        mock_http.return_value = {"success": True}
+        result = self.provider.set_record("test.com", "1.2.3.4")
+        self.assertTrue(result)
+```
+
+### Test Requirements
+1. **Unit tests**: All public methods must have tests with mocked HTTP calls
+2. **Error handling**: Test invalid inputs and network failures
+3. **Python 2.7 compatible**: Use standard library only
+4. **Documentation**: Include docstrings for test methods
+
+### Running Tests
+```bash
+# Run all tests (recommended)
+python -m unittest discover tests -v
+
+# Run specific provider
+python -m unittest tests.test_provider_example -v
+```
+
+See existing tests in `tests/` directory for detailed examples.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -76,7 +76,6 @@ schema/                  # JSON schemas
 
 **Available Methods**:
 - `_http(method, url, ...)` - HTTP/HTTPS requests with automatic error handling
-- `_encode(params)` - URL encoding for query strings and form data
 - `_mask_sensitive_data(data)` - Log-safe data masking for security (supports URL-encoded data)
 
 #### BaseProvider (Full CRUD DNS Provider - Recommended for Most Providers)
@@ -96,8 +95,6 @@ schema/                  # JSON schemas
 
 **Inherited Methods**:
 - `_http()` - HTTP requests with authentication error handling (raises RuntimeError on 401/403)
-- `_encode()` - Parameter encoding for URL query strings and form data
-- `_join_domain(sub, main)` - Domain name construction utility
 - `set_record()` - Automatic record management (orchestrates the above abstract methods)
 
 ## Code Quality Standards

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "ms-python.black-formatter",
-        "ms-vscode.vscode-websearchforcopilot",
         "ms-azuretools.vscode-containers"
     ]
 }

--- a/ddns/provider/_base.py
+++ b/ddns/provider/_base.py
@@ -472,9 +472,7 @@ class BaseProvider(SimpleProvider):
         """
         domain = domain.lower()
         self.logger.info("%s => %s(%s)", domain, value, record_type)
-
-        # 优化域名解析逻辑
-        sub, main = self._split_custom_domain(domain)
+        sub, main = split_custom_domain(domain)
         try:
             if sub is not None:
                 # 使用自定义分隔符格式
@@ -620,42 +618,42 @@ class BaseProvider(SimpleProvider):
             return zone_id, sub, main
         return None, None, main
 
-    @staticmethod
-    def _split_custom_domain(domain):
-        # type: (str) -> tuple[str | None, str]
-        """
-        拆分支持 ~ 或 + 的自定义格式域名为 (子域, 主域)
 
-        如 sub~example.com => ('sub', 'example.com')
+def split_custom_domain(domain):
+    # type: (str) -> tuple[str | None, str]
+    """
+    拆分支持 ~ 或 + 的自定义格式域名为 (子域, 主域)
 
-        Returns:
-            (sub, main): 子域 + 主域
-        """
-        for sep in ("~", "+"):
-            if sep in domain:
-                sub, main = domain.split(sep, 1)
-                return sub, main
-        return None, domain
+    如 sub~example.com => ('sub', 'example.com')
 
-    @staticmethod
-    def _join_domain(sub, main):
-        # type: (str | None, str) -> str
-        """
-        合并子域名和主域名为完整域名
+    Returns:
+        (sub, main): 子域 + 主域
+    """
+    for sep in ("~", "+"):
+        if sep in domain:
+            sub, main = domain.split(sep, 1)
+            return sub, main
+    return None, domain
 
-        Args:
-            sub (str | None): 子域名
-            main (str): 主域名
 
-        Returns:
-            str: 完整域名
-        """
-        sub = sub and sub.strip(".").strip().lower()
-        main = main and main.strip(".").strip().lower()
-        if not sub or sub == "@":
-            if not main:
-                raise ValueError("Both sub and main cannot be empty")
-            return main
+def join_domain(sub, main):
+    # type: (str | None, str) -> str
+    """
+    合并子域名和主域名为完整域名
+
+    Args:
+        sub (str | None): 子域名
+        main (str): 主域名
+
+    Returns:
+        str: 完整域名
+    """
+    sub = sub and sub.strip(".").strip().lower()
+    main = main and main.strip(".").strip().lower()
+    if not sub or sub == "@":
         if not main:
-            return sub
-        return "{}.{}".format(sub, main)
+            raise ValueError("Both sub and main cannot be empty")
+        return main
+    if not main:
+        return sub
+    return "{}.{}".format(sub, main)

--- a/ddns/provider/alidns.py
+++ b/ddns/provider/alidns.py
@@ -5,7 +5,7 @@ AliDNS API
 @author: NewFuture
 """
 
-from ._base import TYPE_FORM, BaseProvider, hmac_sha256_authorization, sha256_hash
+from ._base import TYPE_FORM, BaseProvider, hmac_sha256_authorization, sha256_hash, join_domain
 from time import strftime, gmtime, time
 
 
@@ -66,7 +66,7 @@ class AlidnsProvider(BaseProvider):
 
     def _query_record(self, zone_id, subdomain, main_domain, record_type, line, extra):
         """https://help.aliyun.com/zh/dns/api-alidns-2015-01-09-describesubdomainrecords"""
-        sub = self._join_domain(subdomain, main_domain)
+        sub = join_domain(subdomain, main_domain)
         data = self._request(
             "DescribeSubDomainRecords",
             SubDomain=sub,  # aliyun API要求SubDomain为完整域名
@@ -114,7 +114,7 @@ class AlidnsProvider(BaseProvider):
             and old_record.get("Type") == record_type
             and (not ttl or old_record.get("TTL") == ttl)
         ):
-            domain = self._join_domain(old_record.get("RR"), old_record.get("DomainName"))
+            domain = join_domain(old_record.get("RR"), old_record.get("DomainName"))
             self.logger.warning("No changes detected, skipping update for record: %s", domain)
             return True
         data = self._request(

--- a/ddns/provider/cloudflare.py
+++ b/ddns/provider/cloudflare.py
@@ -4,7 +4,7 @@ CloudFlare API
 @author: TongYifan, NewFuture
 """
 
-from ._base import BaseProvider, TYPE_JSON
+from ._base import BaseProvider, TYPE_JSON, join_domain
 
 
 class CloudflareProvider(BaseProvider):
@@ -51,7 +51,7 @@ class CloudflareProvider(BaseProvider):
         # type: (str, str, str, str, str | None, dict) -> dict | None
         """https://developers.cloudflare.com/api/resources/dns/subresources/records/methods/list/"""
         # cloudflare的域名查询需要完整域名
-        name = self._join_domain(subdomain, main_domain)
+        name = join_domain(subdomain, main_domain)
         query = {"name.exact": name}  # type: dict[str, str|None]
         if extra:
             query["proxied"] = extra.get("proxied", None)  # 代理状态
@@ -66,7 +66,7 @@ class CloudflareProvider(BaseProvider):
     def _create_record(self, zone_id, subdomain, main_domain, value, record_type, ttl, line, extra):
         # type: (str, str, str, str, str, int | str | None, str | None, dict ) -> bool
         """https://developers.cloudflare.com/api/resources/dns/subresources/records/methods/create/"""
-        name = self._join_domain(subdomain, main_domain)
+        name = join_domain(subdomain, main_domain)
         extra["comment"] = extra.get("comment", self.remark)  # 添加注释
         data = self._request(
             "POST", "/{}/dns_records".format(zone_id), name=name, type=record_type, content=value, ttl=ttl, **extra

--- a/ddns/provider/huaweidns.py
+++ b/ddns/provider/huaweidns.py
@@ -5,7 +5,7 @@ HuaweiDNS API
 @author: NewFuture
 """
 
-from ._base import BaseProvider, TYPE_JSON, hmac_sha256_authorization, sha256_hash
+from ._base import BaseProvider, TYPE_JSON, hmac_sha256_authorization, sha256_hash, join_domain
 from json import dumps as jsonencode
 from time import strftime, gmtime
 
@@ -84,7 +84,7 @@ class HuaweiDNSProvider(BaseProvider):
         v2.1 https://support.huaweicloud.com/api-dns/dns_api_64004.html
         v2 https://support.huaweicloud.com/api-dns/ListRecordSetsByZone.html
         """
-        domain = self._join_domain(subdomain, main_domain) + "."
+        domain = join_domain(subdomain, main_domain) + "."
         data = self._request(
             "GET",
             "/v2.1/zones/" + zone_id + "/recordsets",
@@ -103,7 +103,7 @@ class HuaweiDNSProvider(BaseProvider):
         v2.1 https://support.huaweicloud.com/api-dns/dns_api_64001.html
         v2 https://support.huaweicloud.com/api-dns/CreateRecordSet.html
         """
-        domain = self._join_domain(subdomain, main_domain) + "."
+        domain = join_domain(subdomain, main_domain) + "."
         extra["description"] = extra.get("description", self.remark)
         res = self._request(
             "POST",

--- a/doc/dev/provider.md
+++ b/doc/dev/provider.md
@@ -95,8 +95,8 @@ class MySimpleProvider(SimpleProvider):
     支持简单的DNS记录更新，适用于大多数简单DNS API
     """
     API = 'https://api.simpledns.com'
-    ContentType = TYPE_FORM          # 或 TYPE_JSON
-    DecodeResponse = False           # 如果返回纯文本而非JSON，设为False
+    content_type = TYPE_FORM          # 或 TYPE_JSON
+    decode_response = False           # 如果返回纯文本而非JSON，设为False
 
     def _validate(self):
         """验证认证信息（可选重写）"""
@@ -135,24 +135,24 @@ class MyProvider(BaseProvider):
     适用于提供完整CRUD API的DNS服务商
     """
     API = 'https://api.exampledns.com'
-    ContentType = TYPE_JSON  # 或 TYPE_FORM
+    content_type = TYPE_JSON  # 或 TYPE_FORM
 
     def _query_zone_id(self, domain):
-        # type: (str) -> str
+        # type: (str) -> str | None
         """查询主域名的Zone ID"""
         # 精确查找 或者 list匹配
 
     def _query_record(self, zone_id, subdomain, main_domain, record_type, line=None, extra=None):
-        # type: (str, str, str, int | None, str | None, dict | None) -> Any
+        # type: (str, str, str, str, str | None, dict | None) -> Any
         """查询现有DNS记录"""
 
 
     def _create_record(self, zone_id, subdomain, main_domain, value, record_type, ttl=None, line=None, extra=None):
-        # type: (str, str, str, str, int | None, str | None, dict | None) -> bool
+        # type: (str, str, str, str, str, int | str | None, str | None, dict | None) -> bool
         """创建新的DNS记录"""
 
     def _update_record(self, zone_id, old_record, value, record_type, ttl=None, line=None, extra=None):
-        # type: (str, str, str, str, int | None, str | None, dict | None) -> bool
+        # type: (str, dict, str, str, int | str | None, str | None, dict | None) -> bool
         """更新现有DNS记录"""
 
     

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -85,33 +85,38 @@ class TestBaseProvider(BaseProviderTestCase):
 
     def test_split_custom_domain_with_tilde(self):
         """测试用~分隔的自定义域名"""
-        sub, main = BaseProvider._split_custom_domain("www~example.com")
+        from ddns.provider._base import split_custom_domain
+        sub, main = split_custom_domain("www~example.com")
         self.assertEqual(sub, "www")
         self.assertEqual(main, "example.com")
 
     def test_split_custom_domain_with_plus(self):
         """测试用+分隔的自定义域名"""
-        sub, main = BaseProvider._split_custom_domain("api+test.com")
+        from ddns.provider._base import split_custom_domain
+        sub, main = split_custom_domain("api+test.com")
         self.assertEqual(sub, "api")
         self.assertEqual(main, "test.com")
 
     def test_split_custom_domain_no_separator(self):
         """测试没有分隔符的域名"""
-        sub, main = BaseProvider._split_custom_domain("example.com")
+        from ddns.provider._base import split_custom_domain
+        sub, main = split_custom_domain("example.com")
         self.assertIsNone(sub)
         self.assertEqual(main, "example.com")
 
     def test_join_domain_normal(self):
         """测试正常合并域名"""
-        domain = BaseProvider._join_domain("www", "example.com")
+        from ddns.provider._base import join_domain
+        domain = join_domain("www", "example.com")
         self.assertEqual(domain, "www.example.com")
 
     def test_join_domain_empty_sub(self):
         """测试空子域名合并"""
-        domain = BaseProvider._join_domain("", "example.com")
+        from ddns.provider._base import join_domain
+        domain = join_domain("", "example.com")
         self.assertEqual(domain, "example.com")
 
-        domain = BaseProvider._join_domain("@", "example.com")
+        domain = join_domain("@", "example.com")
         self.assertEqual(domain, "example.com")
 
     def test_encode_dict(self):

--- a/tests/test_provider_cloudflare.py
+++ b/tests/test_provider_cloudflare.py
@@ -181,8 +181,8 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _query_record method when no matching record is found"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch("ddns.provider.cloudflare.join_domain") as mock_join, patch.object(
-            provider, "_request"
+        with patch("ddns.provider.cloudflare.join_domain", autospec=True) as mock_join, patch.object(
+            provider, "_request", autospec=True
         ) as mock_request:
 
             mock_join.return_value = "www.example.com"

--- a/tests/test_provider_cloudflare.py
+++ b/tests/test_provider_cloudflare.py
@@ -161,9 +161,7 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _query_record method with successful response"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch.object(provider, "_join_domain") as mock_join, patch.object(provider, "_request") as mock_request:
-
-            mock_join.return_value = "www.example.com"
+        with patch.object(provider, "_request") as mock_request:
             mock_request.return_value = [
                 {"id": "rec123", "name": "www.example.com", "type": "A", "content": "1.2.3.4"},
                 {"id": "rec456", "name": "mail.example.com", "type": "A", "content": "5.6.7.8"},
@@ -173,17 +171,19 @@ class TestCloudflareProvider(BaseProviderTestCase):
                 "zone123", "www", "example.com", "A", None, {}
             )  # type: dict # type: ignore
 
-            mock_join.assert_called_once_with("www", "example.com")
-            params = {"name.exact": "www.example.com"}
-            mock_request.assert_called_once_with("GET", "/zone123/dns_records", type="A", per_page=10000, **params)
             self.assertEqual(result["id"], "rec123")
             self.assertEqual(result["name"], "www.example.com")
+
+            params = {"name.exact": "www.example.com"}
+            mock_request.assert_called_once_with("GET", "/zone123/dns_records", type="A", per_page=10000, **params)
 
     def test_query_record_not_found(self):
         """Test _query_record method when no matching record is found"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch.object(provider, "_join_domain") as mock_join, patch.object(provider, "_request") as mock_request:
+        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+            provider, "_request"
+        ) as mock_request:
 
             mock_join.return_value = "www.example.com"
             mock_request.return_value = [
@@ -198,7 +198,9 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _query_record method with proxy option in extra parameters"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch.object(provider, "_join_domain") as mock_join, patch.object(provider, "_request") as mock_request:
+        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+            provider, "_request"
+        ) as mock_request:
 
             mock_join.return_value = "www.example.com"
             mock_request.return_value = []
@@ -218,14 +220,14 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _create_record method with successful creation"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch.object(provider, "_join_domain") as mock_join, patch.object(provider, "_request") as mock_request:
+        with patch("ddns.provider.cloudflare.join_domain", autospec=True) as mock_join, patch.object(
+            provider, "_request"
+        ) as mock_request:
 
             mock_join.return_value = "www.example.com"
             mock_request.return_value = {"id": "rec123", "name": "www.example.com"}
 
-            result = provider._create_record(
-                "zone123", "www", "example.com", "1.2.3.4", "A", 300, None, {}
-            )  # type: dict # type: ignore
+            result = provider._create_record("zone123", "www", "example.com", "1.2.3.4", "A", 300, None, {})
 
             mock_join.assert_called_once_with("www", "example.com")
             mock_request.assert_called_once_with(
@@ -243,7 +245,9 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _create_record method with failed creation"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch.object(provider, "_join_domain") as mock_join, patch.object(provider, "_request") as mock_request:
+        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+            provider, "_request"
+        ) as mock_request:
 
             mock_join.return_value = "www.example.com"
             mock_request.return_value = None  # API request failed
@@ -256,7 +260,9 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _create_record method with extra parameters"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch.object(provider, "_join_domain") as mock_join, patch.object(provider, "_request") as mock_request:
+        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+            provider, "_request"
+        ) as mock_request:
 
             mock_join.return_value = "www.example.com"
             mock_request.return_value = {"id": "rec123"}

--- a/tests/test_provider_cloudflare.py
+++ b/tests/test_provider_cloudflare.py
@@ -181,7 +181,7 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _query_record method when no matching record is found"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+        with patch("ddns.provider.cloudflare.join_domain") as mock_join, patch.object(
             provider, "_request"
         ) as mock_request:
 
@@ -198,7 +198,7 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _query_record method with proxy option in extra parameters"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+        with patch("ddns.provider.cloudflare.join_domain") as mock_join, patch.object(
             provider, "_request"
         ) as mock_request:
 
@@ -245,7 +245,7 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _create_record method with failed creation"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+        with patch("ddns.provider.cloudflare.join_domain") as mock_join, patch.object(
             provider, "_request"
         ) as mock_request:
 
@@ -260,7 +260,7 @@ class TestCloudflareProvider(BaseProviderTestCase):
         """Test _create_record method with extra parameters"""
         provider = CloudflareProvider(self.auth_id, self.auth_token)
 
-        with patch("ddns.provider._base.join_domain") as mock_join, patch.object(
+        with patch("ddns.provider.cloudflare.join_domain") as mock_join, patch.object(
             provider, "_request"
         ) as mock_request:
 


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the Python-based Dynamic DNS (DDNS) client. Key changes include the addition of development guidelines, refactoring of domain-related utility methods, updates to provider implementations, and adjustments to testing strategies for improved reliability and compatibility.

### Documentation and Development Guidelines
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R81): Added comprehensive contribution guidelines, including coding standards, repository structure, and testing requirements. This provides clear instructions for developers working on the project.

### Refactoring Domain Utility Methods
* [`ddns/provider/_base.py`](diffhunk://#diff-0e27c1358dc2906e34ede404a295e1aa21eb5f95504b800a7b50aaca03165fecL623-R622): Refactored `_split_custom_domain` and `_join_domain` methods into standalone functions (`split_custom_domain` and `join_domain`) to improve reusability and simplify the codebase. [[1]](diffhunk://#diff-0e27c1358dc2906e34ede404a295e1aa21eb5f95504b800a7b50aaca03165fecL623-R622) [[2]](diffhunk://#diff-0e27c1358dc2906e34ede404a295e1aa21eb5f95504b800a7b50aaca03165fecL640-R639)
* Updated all provider implementations (`alidns.py`, `cloudflare.py`, `huaweidns.py`) to use the new `join_domain` function instead of the previous `_join_domain` method. [[1]](diffhunk://#diff-24d84ae60ed46bbf7e4b4bfb553f799b6559edaa79c2f4a66e06fb098d459950L69-R69) [[2]](diffhunk://#diff-56989cd1fd2c70c940abf7b6b48cbb030a29b94e609cb33a02b0d4b1ae18a21fL54-R54) [[3]](diffhunk://#diff-d304cde71ddb03bf2876a7c55835f414233e7c8917b42fae18f90f4d996fd33dL87-R87)

### Provider Implementation Updates
* [`doc/dev/provider.md`](diffhunk://#diff-bd04dd0f874e2d4bc525e2f38f4e6982df5da4a925d93613f426b08aa326ffb9L98-R99): Updated type hints and renamed attributes (`ContentType` → `content_type`, `DecodeResponse` → `decode_response`) for better alignment with Python conventions and improved clarity. [[1]](diffhunk://#diff-bd04dd0f874e2d4bc525e2f38f4e6982df5da4a925d93613f426b08aa326ffb9L98-R99) [[2]](diffhunk://#diff-bd04dd0f874e2d4bc525e2f38f4e6982df5da4a925d93613f426b08aa326ffb9L138-R155)
* `ddns/provider/alidns.py`, `ddns/provider/cloudflare.py`, `ddns/provider/huaweidns.py`: Adjusted domain-related logic to use the refactored utility functions, ensuring consistency across implementations. [[1]](diffhunk://#diff-24d84ae60ed46bbf7e4b4bfb553f799b6559edaa79c2f4a66e06fb098d459950L117-R117) [[2]](diffhunk://#diff-56989cd1fd2c70c940abf7b6b48cbb030a29b94e609cb33a02b0d4b1ae18a21fL69-R69) [[3]](diffhunk://#diff-d304cde71ddb03bf2876a7c55835f414233e7c8917b42fae18f90f4d996fd33dL106-R106)

### Testing Enhancements
* [`tests/test_provider_base.py`](diffhunk://#diff-d5d49e77a6d9bf930c7151c947fa6380a379c570477dd9280195217670d36f8bL88-R119): Updated tests to use the new `split_custom_domain` and `join_domain` functions, ensuring coverage for the refactored methods.
* [`tests/test_provider_callback.py`](diffhunk://#diff-479accda9a6369260bb4bd3f9d8448d082e50a62e17750dff9c72f5cd4881f64L278-R288): Improved integration tests by adding conditional skips for unsupported CI environments and retry logic for real HTTP requests to enhance reliability. [[1]](diffhunk://#diff-479accda9a6369260bb4bd3f9d8448d082e50a62e17750dff9c72f5cd4881f64L278-R288) [[2]](diffhunk://#diff-479accda9a6369260bb4bd3f9d8448d082e50a62e17750dff9c72f5cd4881f64R336-R343)

### Miscellaneous Updates
* [`.vscode/extensions.json`](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912L8): Removed an unused extension (`ms-vscode.vscode-websearchforcopilot`) to streamline the development environment.
* [`.github/instructions/python.instructions.md`](diffhunk://#diff-a31690c34a58a15f6fa7454f86cb05595cde189ab5f01f8b4f8944e31cc377a6L79): Removed redundant `_encode` method references from documentation to align with recent code changes. [[1]](diffhunk://#diff-a31690c34a58a15f6fa7454f86cb05595cde189ab5f01f8b4f8944e31cc377a6L79) [[2]](diffhunk://#diff-a31690c34a58a15f6fa7454f86cb05595cde189ab5f01f8b4f8944e31cc377a6L99-L100)