### PR TITLE
fix(cli): new config default path

### DIFF
--- a/ddns/config/cli.py
+++ b/ddns/config/cli.py
@@ -82,7 +82,8 @@ class NewConfigAction(Action):
         if values and values != "true":
             config_path = str(values)  # type: str
         else:
-            config_path = getattr(namespace, "config", "config.json")  # type: str
+            config_path = getattr(namespace, "config") or "config.json"  # type: str
+            config_path = config_path[0] if isinstance(config_path, list) else config_path
             if os_path.exists(config_path):
                 sys.stderr.write("The default %s already exists!\n" % config_path)
                 sys.stdout.write("Please use `--new-config=%s` to specify a new config file.\n" % config_path)

--- a/ddns/config/cli.py
+++ b/ddns/config/cli.py
@@ -82,7 +82,7 @@ class NewConfigAction(Action):
         if values and values != "true":
             config_path = str(values)  # type: str
         else:
-            config_path = getattr(namespace, "config") or "config.json"  # type: str
+            config_path = getattr(namespace, "config", None) or "config.json"  # type: str
             config_path = config_path[0] if isinstance(config_path, list) else config_path
             if os_path.exists(config_path):
                 sys.stderr.write("The default %s already exists!\n" % config_path)


### PR DESCRIPTION
This pull request includes a minor update to the `ddns/config/cli.py` file. The change refines how the default configuration path is determined when the `config` attribute in `namespace` is a list.

* [`ddns/config/cli.py`](diffhunk://#diff-0723443ecdc201b3b39bfa650d35b046070cc766a6aee9947aed75144bf6d827L85-R86): Updated the logic for setting `config_path` to handle cases where `namespace.config` is a list, ensuring the first element of the list is used as the path.