### PR TITLE
feat(cache): add configurable cache max age

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -185,6 +185,7 @@ ddns -c https://ddns.newfuture.cc/tests/config/debug.json
 |  ssl   |  string\|boolean   |    No    |  `"auto"`   | SSL Certificate Verification | `true` (force verify), `false` (disable verify), `"auto"` (auto downgrade) or custom CA certificate file path                                                                         |
 | debug  |        bool        |    No    |   `false`   |    Enable Debug    | Debug mode, only effective with command line parameter `--debug`                                                                                                                       |
 | cache  |    string\|bool    |    No    |   `true`    |    Cache Records   | Keep enabled normally to avoid frequent updates, default location is `ddns.cache` in temp directory, can also specify a specific path                                                |
+| cache_max_age | integer | No | `259200` | Cache file max age (seconds) | `0` clears an existing cache on every invocation; this is local file expiry, not DNS TTL |
 |  log   |       object       |    No    |   `null`    |  Log Config (Optional) | Log configuration object, supports `level`, `file`, `format`, `datefmt` parameters                                                                                                     |
 
 #### index4 and index6 Parameter Description

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ ddns -c https://ddns.newfuture.cc/tests/config/debug.json
 |  ssl   |  string\|boolean   |    No    |  `"auto"`   | SSL证书验证方式    | `true`（强制验证）、`false`（禁用验证）、`"auto"`（自动降级）或自定义CA证书文件路径                                                                                    |
 | debug  |        bool        |    No    |   `false`   |    是否开启调试    | 调试模式，仅命令行参数`--debug`有效                                                                                                                                    |
 | cache  |    string\|bool    |    No    |   `true`    |    是否缓存记录    | 正常情况打开避免频繁更新，默认位置为临时目录下 `ddns.cache`，也可以指定一个具体路径                                                                                                      |
+| cache_max_age | integer | No | `259200` | 缓存文件最大有效期（秒） | `0` 表示每次运行清空已有缓存；这是本地文件有效期，不是 DNS TTL |
 |  log   |       object       |    No    |   `null`    |  日志配置（可选）  | 日志配置对象，支持`level`、`file`、`format`、`datefmt`参数                                                                                                                               |
 
 #### index4 和 index6 参数说明

--- a/ddns/__main__.py
+++ b/ddns/__main__.py
@@ -109,7 +109,7 @@ def run(config):
     dns = provider_class(
         config.id, config.token, endpoint=config.endpoint, logger=logger, proxy=config.proxy, ssl=config.ssl
     )
-    cache = Cache.new(config.cache, config.md5(), logger)
+    cache = Cache.new(config.cache, config.md5(), logger, config.cache_max_age)
     return (
         update_ip(dns, cache, config.index4, config.ipv4, "A", config) is not False
         and update_ip(dns, cache, config.index6, config.ipv6, "AAAA", config) is not False

--- a/ddns/cache.py
+++ b/ddns/cache.py
@@ -155,8 +155,8 @@ class Cache(dict):
         self.close()
 
     @staticmethod
-    def new(config_cache, hash, logger):
-        # type: (str|bool, str, Logger) -> Cache|None
+    def new(config_cache, hash, logger, cache_max_age=259200):
+        # type: (str|bool, str, Logger, int) -> Cache|None
         """
         new cache from a file path.
         :param path: Path to the cache file.
@@ -173,11 +173,14 @@ class Cache(dict):
 
         if cache is None:
             logger.debug("Cache is disabled!")
-        elif cache.time + 72 * 3600 < time():  # 72小时有效期
-            logger.info("Cache file is outdated.")
-            cache.clear()
-        elif len(cache) == 0:
-            logger.debug("Cache is empty.")
         else:
-            logger.debug("Cache loaded with %d entries.", len(cache))
+            now = time()
+            expired = cache.time > now or now - cache.time >= cache_max_age
+            if expired:
+                logger.info("Cache file is outdated.")
+                cache.clear()
+            elif len(cache) == 0:
+                logger.debug("Cache is empty.")
+            else:
+                logger.debug("Cache loaded with %d entries.", len(cache))
         return cache

--- a/ddns/config/cli.py
+++ b/ddns/config/cli.py
@@ -6,7 +6,7 @@ Configuration loader for DDNS command-line interface.
 
 import platform
 import sys
-from argparse import SUPPRESS, Action, ArgumentParser, RawTextHelpFormatter
+from argparse import SUPPRESS, Action, ArgumentParser, ArgumentTypeError, RawTextHelpFormatter
 from logging import DEBUG, basicConfig, getLevelName
 from os import path as os_path
 
@@ -33,6 +33,18 @@ def str_bool(v):
         return False
     else:
         return v  # type: ignore[return-value]
+
+
+def non_negative_int(value):
+    # type: (str) -> int
+    """Parse a non-negative integer CLI option."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ArgumentTypeError("must be a non-negative integer")
+    if parsed < 0:
+        raise ArgumentTypeError("must be a non-negative integer")
+    return parsed
 
 
 def log_level(value):
@@ -163,6 +175,13 @@ def _add_ddns_args(arg):  # type: (ArgumentParser) -> None
     advanced.add_argument("--proxy", nargs="*", action=ExtendAction, help="HTTP proxy [设置http代理，可配多个代理连接]")
     advanced.add_argument(
         "--cache", type=str_bool, nargs="?", const=True, help="set cache [启用缓存开关，或传入保存路径]"
+    )
+    advanced.add_argument(
+        "--cache-max-age",
+        "--cache_max_age",
+        dest="cache_max_age",
+        type=non_negative_int,
+        help="cache file max age in seconds [缓存文件最大有效期，单位秒]",
     )
     advanced.add_argument(
         "--no-cache", dest="cache", action="store_const", const=False, help="disable cache [关闭缓存等效 --cache=false]"

--- a/ddns/config/config.py
+++ b/ddns/config/config.py
@@ -5,6 +5,8 @@ Configuration class merged from CLI, JSON, and environment variables.
 """
 
 from hashlib import md5
+from numbers import Integral
+
 from .cli import str_bool, log_level as get_log_level
 
 __all__ = ["Config", "split_array_string"]
@@ -88,6 +90,7 @@ class Config(object):
             "line",
             "proxy",
             "cache",
+            "cache_max_age",
             "ssl",
             "log_level",
             "log_format",
@@ -115,6 +118,7 @@ class Config(object):
         self.proxy = self._get("proxy", [])  # type: list[str] | None
         # cache and SSL settings
         self.cache = str_bool(self._get("cache", True))
+        self.cache_max_age = self._get_cache_max_age()
         self.ssl = str_bool(self._get("ssl", "auto"))
 
         log_level = self._get("log_level", "INFO")
@@ -145,6 +149,22 @@ class Config(object):
         if key in SIMPLE_ARRAY_PARAMS:
             return split_array_string(value)
         return value
+
+    def _get_cache_max_age(self):
+        # type: () -> int
+        value = self._get("cache_max_age", 259200)
+        if isinstance(value, bool):
+            raise ValueError("cache_max_age must be a non-negative integer")
+        if isinstance(value, (str, bytes)):
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                raise ValueError("cache_max_age must be a non-negative integer")
+        elif not isinstance(value, Integral):
+            raise ValueError("cache_max_age must be a non-negative integer")
+        if value < 0:
+            raise ValueError("cache_max_age must be a non-negative integer")
+        return int(value)
 
     def _process_extra_from_source(self, source_config, extra, process_nested_extra=True):
         # type: (dict, dict, bool) -> None
@@ -208,6 +228,7 @@ class Config(object):
             "ttl": self.ttl,
             # System settings
             "cache": self.cache,
+            "cache_max_age": self.cache_max_age,
             "proxy": self.proxy,
             "ssl": self.ssl,
             # Logging settings

--- a/ddns/config/file.py
+++ b/ddns/config/file.py
@@ -161,6 +161,7 @@ def save_config(config_path, config):
         "line": config.get("line"),
         "proxy": config.get("proxy", []),
         "cache": config.get("cache", True),
+        "cache_max_age": config.get("cache_max_age", 259200),
         "ssl": config.get("ssl", "auto"),
         "log": {
             "file": config.get("log_file"),

--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -81,6 +81,7 @@ ddns --ipv4=example.com,www.example.com
 | `--line`        | 字符串      | 解析线路(部分provider支持)，如 ISP线路                                                                                                                         | `--line 电信` <br> `--line telecom`                        |
 | `--proxy`       | 字符串列表    | HTTP 代理设置，支持：`http://host:port`、`DIRECT`(直连)、`SYSTEM`(系统代理)                                                      | `--proxy SYSTEM DIRECT` 或 `--proxy http://127.0.0.1:1080 --proxy DIRECT`    |
 | `--cache`       | 标志/字符串   | 是否启用缓存或自定义缓存路径                                                                                                                           | `--cache` <br> `--cache=/path/to/cache`        |
+| `--cache-max-age`, `--cache_max_age` | 非负整数（秒） | 缓存文件最大有效期；默认 `259200` 秒，`0` 表示每次运行清空已有缓存 | `--cache-max-age 86400` |
 | `--no-cache`    | 标志       | 禁用缓存（等效于 `--cache=false`）                                                                                                                | `--no-cache`                                             |
 | `--ssl`         | 字符串      | SSL 证书验证方式，支持：true, false, auto, 文件路径                                                                                                    | `--ssl false` <br> `--ssl=/path/to/ca-certs.crt`             |
 | `--no-ssl`      | 标志       | 禁用 SSL 验证（等效于 `--ssl=false`）                                                                                                             | `--no-ssl`                                               |
@@ -260,6 +261,10 @@ HTTP代理设置，支持多代理轮换。代理类型包括：
   - `--cache` (启用默认缓存)
   - `--cache=false` (禁用缓存)
   - `--cache=/path/to/ddns.cache` (自定义缓存路径)
+
+### `--cache-max-age SECONDS`
+
+设置整个缓存文件的有效期，默认 259200 秒（72 小时）。在下一次运行时，若当前时间减去文件修改时间大于或等于该值，或文件修改时间在未来，则清空文件中的所有公开缓存项；`0` 会在每次运行清空已有缓存。该设置不是 DNS TTL。缓存采用单一文件 mtime：任何缓存内容写入都会刷新整个文件，因此所有记录共享这个有效期。缓存文件仍使用原有扁平 JSON 格式，不会迁移；共享缓存文件的既有限制不变。
 
 ### `--ssl {true|false|auto|PATH}`
 

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -26,6 +26,7 @@ DDNS 支持通过环境变量进行配置，环境变量的优先级为：**[命
 | `DDNS_LINE`            | 依服务商而定，如：电信、移动                                                                        | DNS 解析线路                      | `DDNS_LINE=电信`                                         |
 | `DDNS_PROXY`           | `http://host:port` 或 DIRECT，支持多代理数组或分号分隔                                              | HTTP 代理设置                     | `DDNS_PROXY="http://127.0.0.1:1080;DIRECT"`              |
 | `DDNS_CACHE`           | true、false 或文件路径                                                                              | 启用缓存或指定缓存文件路径        | `DDNS_CACHE="/tmp/cache"`                                |
+| `DDNS_CACHE_MAX_AGE`   | 非负整数（秒）                                                                                       | 缓存文件最大有效期，默认 259200，0 表示每次运行清空已有缓存 | `DDNS_CACHE_MAX_AGE=86400` |
 | `DDNS_SSL`             | true、false、auto 或文件路径                                                                         | 设置 SSL 验证方式或指定证书路径   | `DDNS_SSL=false`<br>`DDNS_SSL=/path/ca.crt`              |
 | `DDNS_CRON`            | Cron 表达式格式字符串（仅 Docker 环境有效）                                                          | Docker 容器内定时任务周期         | `DDNS_CRON="*/10 * * * *"`                               |
 | `DDNS_LOG_LEVEL`       | DEBUG、INFO、WARNING、ERROR、CRITICAL                                                               | 设置日志等级                      | `DDNS_LOG_LEVEL="DEBUG"`                                 |
@@ -224,7 +225,10 @@ DDNS 支持通过环境变量进行配置，环境变量的优先级为：**[命
   
   # 自定义缓存文件路径
   export DDNS_CACHE="/path/to/ddns.cache"
+
   ```
+
+`DDNS_CACHE_MAX_AGE` 控制整个缓存文件的有效期（秒），在下一次运行时按文件 mtime 判断，边界值也算过期，未来 mtime 也算过期。它不是 DNS TTL；缓存仍是扁平 JSON，任何内容写入都会刷新整个文件并影响所有记录，不进行迁移，共享缓存限制不变。
 
 ### SSL证书验证
 

--- a/docs/config/json.md
+++ b/docs/config/json.md
@@ -64,6 +64,7 @@ DDNS配置文件遵循JSON模式(Schema)，推荐在配置文件中添加`$schem
 |  proxy   | string\|array      |  否  |     无      | HTTP代理          | 多代理逐个尝试直到成功，支持`DIRECT`(直连)、`SYSTEM`(系统代理)                                              |
 |   ssl    | string\|boolean    |  否  |  `"auto"`   | SSL验证方式    | `true`（强制验证）、`false`（禁用验证）、`"auto"`（自动降级）或自定义CA证书文件路径                          |
 |  cache   |    string\|bool    |  否  |   `true`    | 是否缓存记录       | 正常情况打开避免频繁更新，默认位置为临时目录下`ddns.{hash}.cache`，也可以指定具体路径                              |
+| cache_max_age | integer | 否 | `259200` | 缓存文件最大有效期（秒） | `0` 表示下一次运行清空已有缓存；与 DNS TTL 无关 |
 |  log     |       object       |  否  |   `null`    | 日志配置  | 日志配置对象，支持`level`、`file`、`format`、`datefmt`参数                                                |
 
 ### dns
@@ -177,6 +178,10 @@ DDNS配置文件遵循JSON模式(Schema)，推荐在配置文件中添加`$schem
 * `true`：启用缓存，默认位置为临时目录下的`ddns.{hash}.cache`
 * `false`：禁用缓存
 * `"/path/to/cache.file"`：指定自定义缓存文件路径
+
+### cache_max_age
+
+缓存文件按整体 mtime 判断有效期，单位为秒，默认 259200（72 小时）。下一次运行时，`now - mtime >= cache_max_age` 或 mtime 在未来即视为过期；设置为 `0` 会在每次运行清空已有缓存。缓存仍为原有扁平 JSON，不保存每条记录时间戳，也不迁移。由于整个文件只有一个 mtime，任何缓存内容写入都会刷新所有记录的有效期；共享缓存文件的限制不变。
 
 ### log
 

--- a/docs/en/config/cli.md
+++ b/docs/en/config/cli.md
@@ -78,6 +78,7 @@ ddns --ipv4=example.com,www.example.com
 | `--line`        |    String   | DNS resolution line (e.g. ISP line)                                                                                                                                       | `--line 电信` <br> `--line telecom`                        |
 | `--proxy`       | String List | HTTP proxy settings, supports: `http://host:port`, `DIRECT`(direct), `SYSTEM`(system proxy)                                | `--proxy SYSTEM DIRECT` or `--proxy http://127.0.0.1:1080 --proxy DIRECT`    |
 | `--cache`       | Flag/String | Enable cache or specify custom cache path                                                                                                                                 | `--cache` <br> `--cache=/path/to/cache`                  |
+| `--cache-max-age`, `--cache_max_age` | Non-negative integer (seconds) | Maximum cache file age; default `259200` seconds, `0` clears an existing cache on every invocation | `--cache-max-age 86400` |
 | `--no-cache`    |     Flag    | Disable cache (equivalent to `--cache=false`)                                                                                                                             | `--no-cache`                                             |
 | `--ssl`         |    String   | SSL certificate verification: true, false, auto, or file path                                                                                                             | `--ssl false` <br> `--ssl=/path/to/ca-certs.crt`         |
 | `--no-ssl`      |     Flag    | Disable SSL verification (equivalent to `--ssl=false`)                                                                                                                    | `--no-ssl`                                               |
@@ -85,6 +86,8 @@ ddns --ipv4=example.com,www.example.com
 | `--log_level`   |    String   | Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL                                                                                                                      | `--log_level=ERROR`                                      |
 | `--log_format`  |    String   | Log format string (compatible with Python `logging` module)                                                                                                               | `--log_format="%(asctime)s:%(message)s"`                 |
 | `--log_datefmt` |    String   | Date/time format string for logs                                                                                                                                          | `--log_datefmt="%Y-%m-%d %H:%M:%S"`                      |
+
+`--cache-max-age` controls whole-file cache expiry, in seconds. The default is 259200 (72 hours). On the next invocation, a cache is stale when `now - mtime >= cache_max_age` or its mtime is in the future; `0` clears an existing cache every time. This is distinct from DNS TTL. The flat JSON file has one mtime, so any cache write refreshes the age for every entry. The format is unchanged and no migration is performed; existing shared-cache limitations remain.
 
 #### Task Subcommand Parameters
 

--- a/docs/en/config/env.md
+++ b/docs/en/config/env.md
@@ -26,6 +26,7 @@ All environment variables use the `DDNS_` prefix followed by the parameter name 
 | `DDNS_LINE`              | ISP line such as: 电信, 联通, 移动, or provider-specific values                                     | DNS resolution line                       | `DDNS_LINE=电信`                                            |
 | `DDNS_PROXY`             | `http://host:port` or `DIRECT`, multiple values separated by semicolons                             | HTTP proxy settings                       | `DDNS_PROXY="http://127.0.0.1:1080;DIRECT"`                 |
 | `DDNS_CACHE`             | `true`, `false`, or file path                                                                        | Enable or specify cache file              | `DDNS_CACHE="/tmp/cache"`                                   |
+| `DDNS_CACHE_MAX_AGE`     | Non-negative integer (seconds)                                                                       | Whole cache file max age; default 259200, `0` clears an existing cache every invocation | `DDNS_CACHE_MAX_AGE=86400` |
 | `DDNS_SSL`               | `true`, `false`, `auto`, or file path                                                                | SSL verification mode or certificate path | `DDNS_SSL=false`<br>`DDNS_SSL=/path/ca.crt`                 |
 | `DDNS_CRON`              | Cron expression format string (Docker only)                                                          | Cron schedule for Docker container        | `DDNS_CRON="*/10 * * * *"`                                  |
 | `DDNS_LOG_LEVEL`         | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`                                                     | Logging level                             | `DDNS_LOG_LEVEL="DEBUG"`                                    |
@@ -377,10 +378,12 @@ export DDNS_TOKEN='{"api_key": "your_key", "domain": "__DOMAIN__", "ip": "__IP__
   
   # Custom cache file path
   export DDNS_CACHE="/var/cache/ddns/cache.json"
-  
+
   # Use temporary directory
   export DDNS_CACHE="/tmp/ddns.cache"
   ```
+
+`DDNS_CACHE_MAX_AGE` controls whole-file expiry in seconds. Expiry is checked on the next invocation; the exact boundary is stale and a future mtime is stale. It is not DNS TTL. The cache remains flat JSON with one mtime, so any content write refreshes every entry; no migration is performed and shared-cache limitations are unchanged.
 
 ### Docker Cron Schedule Configuration
 

--- a/docs/en/config/json.md
+++ b/docs/en/config/json.md
@@ -69,6 +69,7 @@ Configuration Parameters Table
 | proxy | string\|array | No | None | HTTP Proxy | Try multiple proxies sequentially until success, supports `DIRECT`(direct), `SYSTEM`(system proxy) |
 | ssl | string\|boolean | No | `"auto"` | SSL Verification Method | `true` (force verification), `false` (disable verification), `"auto"` (auto downgrade) or custom CA certificate file path |
 | cache | string\|bool | No | `true` | Enable Record Caching | Enable to avoid frequent updates, default location is `ddns.{hash}.cache` in temp directory, or specify custom path |
+| cache_max_age | integer | No | `259200` | Cache File Max Age (seconds) | `0` clears an existing cache on the next invocation; distinct from DNS TTL |
 | log | object | No | `null` | Log Configuration | Log configuration object, supports `level`, `file`, `format`, `datefmt` parameters |
 
 ### dns
@@ -182,6 +183,10 @@ The `cache` parameter is used to configure DNS record caching method. The follow
 * `true`: Enable caching, default location is `ddns.{hash}.cache` in the temporary directory
 * `false`: Disable caching
 * `"/path/to/cache.file"`: Specify custom cache file path
+
+### cache_max_age
+
+The whole cache file is evaluated by its mtime, in seconds, with a default of 259200 (72 hours). On the next invocation, `now - mtime >= cache_max_age` or a future mtime is stale; `0` clears an existing cache every time. The cache remains the original flat JSON without per-record timestamps or migration. Because the file has one mtime, any cache content write refreshes the age for every entry; shared-cache limitations are unchanged.
 
 ### log
 

--- a/schema/v4.1.json
+++ b/schema/v4.1.json
@@ -170,6 +170,13 @@
               "/path/to/cache/ddns.cache"
             ]
           },
+          "cache_max_age": {
+            "type": "integer",
+            "minimum": 0,
+            "title": "Cache Max Age",
+            "description": "缓存文件最大有效期（秒）；0表示每次启动都清空已有缓存",
+            "default": 259200
+          },
           "log": {
             "type": "object",
             "title": "Log Config",
@@ -485,6 +492,18 @@
         true,
         false,
         "/path/to/cache/ddns.cache"
+      ]
+    },
+    "cache_max_age": {
+      "$id": "/properties/cache_max_age",
+      "type": "integer",
+      "minimum": 0,
+      "title": "Cache Max Age",
+      "description": "Maximum cache file age in seconds; 0 clears an existing cache on every invocation",
+      "default": 259200,
+      "examples": [
+        259200,
+        0
       ]
     },
     "ssl": {

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -667,6 +667,46 @@ class TestCache(unittest.TestCase):
         # Clean up
         cache.close()
 
+    @patch("ddns.cache.time")
+    def test_cache_new_custom_max_age_and_boundary(self, mock_time):
+        """Test custom age, exact expiry boundary, and future mtimes."""
+        import json
+        import logging
+
+        with open(self.cache_file, "w") as data:
+            json.dump({"record": "1.2.3.4"}, data)
+        logger = logging.getLogger("test_logger")
+        mock_time.return_value = 1000
+
+        with patch("ddns.cache.stat") as mock_stat:
+            mock_stat.return_value.st_mtime = 900
+            cache = Cache.new(self.cache_file, "hash", logger, 100)
+        self.assertEqual(len(cache), 0)
+        cache.close()
+
+        with open(self.cache_file, "w") as data:
+            json.dump({"record": "1.2.3.4"}, data)
+        with patch("ddns.cache.stat") as mock_stat:
+            mock_stat.return_value.st_mtime = 1001
+            cache = Cache.new(self.cache_file, "hash", logger, 100)
+        self.assertEqual(len(cache), 0)
+        cache.close()
+
+    @patch("ddns.cache.time")
+    def test_cache_new_zero_age_clears_existing_cache(self, mock_time):
+        """Test zero max age clears all existing public entries."""
+        import json
+        import logging
+
+        with open(self.cache_file, "w") as data:
+            json.dump({"a": 1, "b": 2}, data)
+        mock_time.return_value = 1000
+        with patch("ddns.cache.stat") as mock_stat:
+            mock_stat.return_value.st_mtime = 1000
+            cache = Cache.new(self.cache_file, "hash", logging.getLogger("test_logger"), 0)
+        self.assertEqual(len(cache), 0)
+        cache.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -79,6 +79,13 @@ class TestCliConfig(unittest.TestCase):
         self.assertEqual(config["token"], "secret123")
         self.assertTrue(config["debug"])
 
+    def test_load_config_cache_max_age_aliases(self):
+        """Test both cache max age CLI spellings."""
+        for option in ["--cache-max-age", "--cache_max_age"]:
+            sys.argv = ["ddns", option, "86400"]
+            config = load_config("Test DDNS", "Test doc", "1.0.0", "2025-07-04")
+            self.assertEqual(config["cache_max_age"], 86400)
+
     def test_load_config_with_arrays(self):
         """Test load_config with array arguments"""
         sys.argv = ["ddns", "--ipv4", "example.com", "test.com", "--proxy", "http://proxy1.com", "http://proxy2.com"]

--- a/tests/test_config_config.py
+++ b/tests/test_config_config.py
@@ -58,6 +58,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.ssl, "auto")
         self.assertEqual(config.log_level, 20)
         self.assertEqual(config.log_datefmt, "%Y-%m-%dT%H:%M:%S")
+        self.assertEqual(config.cache_max_age, 259200)
 
         # CLI configuration
         cli_config = {
@@ -75,6 +76,18 @@ class TestConfig(unittest.TestCase):
         self.assertFalse(config.cache)
         self.assertTrue(config.ssl)
         self.assertEqual(config.log_level, 10)
+
+    def test_cache_max_age_validation_and_precedence(self):
+        """Test cache max age conversion, inheritance, and validation."""
+        config = Config(env_config={"cache_max_age": "60"})
+        self.assertEqual(config.cache_max_age, 60)
+        config = Config(json_config={"cache_max_age": 120}, env_config={"cache_max_age": 60})
+        self.assertEqual(config.cache_max_age, 120)
+        config = Config(cli_config={"cache_max_age": "0"})
+        self.assertEqual(config.cache_max_age, 0)
+        for value in [True, False, -1, "invalid", 1.5]:
+            with self.assertRaises(ValueError):
+                Config(cli_config={"cache_max_age": value})
 
         # JSON configuration
         json_config = {

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -94,6 +94,15 @@ class TestConfigEnv(unittest.TestCase):
         self.assertEqual(config.get("proxy"), "http://ddns.proxy.com:9090")
         del os.environ["DDNS_PROXY"]
 
+    def test_ddns_cache_max_age(self):
+        """Test DDNS_CACHE_MAX_AGE is loaded by generic environment handling."""
+        os.environ["DDNS_CACHE_MAX_AGE"] = "86400"
+
+        config = load_config()
+
+        self.assertEqual(config.get("cache_max_age"), "86400")
+        del os.environ["DDNS_CACHE_MAX_AGE"]
+
     def test_ddns_variables_override_standard_vars(self):
         """Test that DDNS variables take precedence over standard environment variables"""
         self._clear_standard_env()

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -317,6 +317,7 @@ class TestConfigFile(unittest.TestCase):
         # Check that schema and other defaults are added
         self.assertIn("$schema", loaded_config)
         self.assertIn("cache", loaded_config)
+        self.assertEqual(loaded_config["cache_max_age"], 259200)
 
     def test_save_config_complex_data(self):
         """Test saving configuration with complex data types"""

--- a/tests/test_config_init_multi.py
+++ b/tests/test_config_init_multi.py
@@ -192,6 +192,21 @@ class TestMultiConfig(unittest.TestCase):
         ali_config = result[1]
         self.assertEqual(ali_config["proxy"], "http://global.proxy:8080")
 
+    def test_multi_provider_cache_max_age_inheritance_and_override(self):
+        """Test global cache_max_age inheritance and provider override, including zero."""
+        config = {
+            "cache_max_age": 86400,
+            "providers": [
+                {"provider": "debug", "token": "global", "ipv4": ["global.example.com"]},
+                {"provider": "debug", "token": "override", "ipv4": ["override.example.com"], "cache_max_age": 0},
+            ],
+        }
+
+        result = _process_multi_providers(config)
+
+        self.assertEqual(result[0]["cache_max_age"], 86400)
+        self.assertEqual(result[1]["cache_max_age"], 0)
+
     def test_multi_provider_proxy_array_format(self):
         """测试provider级别的数组格式proxy配置"""
         config = {

--- a/tests/test_config_schema_v4_1.py
+++ b/tests/test_config_schema_v4_1.py
@@ -157,6 +157,21 @@ class TestAllConfigFormatsIntegration(unittest.TestCase):
         self.assertEqual(loaded["dns"], "debug")
         self.assertEqual(loaded["token"], "test")
 
+    def test_cache_max_age_schema_definitions(self):
+        """Test root and provider cache_max_age schema definitions."""
+        schema_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema", "v4.1.json")
+        with open(schema_path, "r") as schema_file:
+            schema = json.load(schema_file)
+
+        definitions = [
+            schema["properties"]["cache_max_age"],
+            schema["properties"]["providers"]["items"]["properties"]["cache_max_age"],
+        ]
+        for definition in definitions:
+            self.assertEqual(definition["type"], "integer")
+            self.assertEqual(definition["minimum"], 0)
+            self.assertEqual(definition["default"], 259200)
+
     def test_v40_to_v41_compatibility(self):
         """Test v4.0 config is compatible with v4.1 processing"""
         from ddns.config.file import load_config

--- a/tests/test_config_schema_v4_1.py
+++ b/tests/test_config_schema_v4_1.py
@@ -160,7 +160,7 @@ class TestAllConfigFormatsIntegration(unittest.TestCase):
     def test_cache_max_age_schema_definitions(self):
         """Test root and provider cache_max_age schema definitions."""
         schema_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema", "v4.1.json")
-        with open(schema_path, "r") as schema_file:
+        with open(schema_path, "rb") as schema_file:
             schema = json.load(schema_file)
 
         definitions = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,7 +26,7 @@ class TestMain(unittest.TestCase):
                 "cache_max_age": 86400,
                 "index4": False,
                 "index6": False,
-            }
+            },
         )
 
         self.assertTrue(__main__.run(config))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,13 +20,7 @@ class TestMain(unittest.TestCase):
         provider = MagicMock()
         mock_provider_class.return_value = lambda *args, **kwargs: provider
         config = Config(
-            cli_config={
-                "dns": "debug",
-                "cache": True,
-                "cache_max_age": 86400,
-                "index4": False,
-                "index6": False,
-            },
+            cli_config={"dns": "debug", "cache": True, "cache_max_age": 86400, "index4": False, "index6": False}
         )
 
         self.assertTrue(__main__.run(config))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the DDNS main run path.
+"""
+
+from __init__ import MagicMock, patch, unittest
+
+from ddns import __main__
+from ddns.config.config import Config
+
+
+class TestMain(unittest.TestCase):
+    """Test the main DDNS run path."""
+
+    @patch.object(__main__, "update_ip", return_value=True)
+    @patch.object(__main__.Cache, "new")
+    @patch.object(__main__, "get_provider_class")
+    def test_run_passes_cache_max_age_to_cache(self, mock_provider_class, mock_cache_new, mock_update_ip):
+        """Test run passes cache_max_age as the fourth Cache.new argument."""
+        provider = MagicMock()
+        mock_provider_class.return_value = lambda *args, **kwargs: provider
+        config = Config(
+            cli_config={
+                "dns": "debug",
+                "cache": True,
+                "cache_max_age": 86400,
+                "index4": False,
+                "index6": False,
+            }
+        )
+
+        self.assertTrue(__main__.run(config))
+        mock_cache_new.assert_called_once_with(True, config.md5(), __main__.logger, 86400)
+        self.assertEqual(mock_update_ip.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler_base.py
+++ b/tests/test_scheduler_base.py
@@ -129,6 +129,13 @@ class TestBaseScheduler(unittest.TestCase):
         self.assertIn("--ttl", command)
         self.assertIn("600", command)
 
+    def test_build_ddns_command_with_cache_max_age(self):
+        """Test _build_ddns_command emits the cache max age option."""
+        command = self.scheduler._build_ddns_command({"cache_max_age": 86400})
+
+        self.assertIn("--cache_max_age", command)
+        self.assertIn("86400", command)
+
     def test_build_ddns_command_excludes_none_values(self):
         """Test _build_ddns_command behavior with None values"""
         ddns_args = {"dns": "debug", "ipv4": ["test.com"], "ttl": None, "line": None}


### PR DESCRIPTION
## Summary

- Adds `cache_max_age` for configurable whole-cache-file mtime expiry.
- Keeps the existing flat `domain:record_type -> address` JSON format with no per-record timestamps, counters, or migration.
- Supports JSON, `--cache-max-age` / `--cache_max_age`, `DDNS_CACHE_MAX_AGE`, generated config, v4.1 global/provider configuration, and scheduled commands.

## Behavior

- Default: `259200` seconds (72 hours), preserving the previous hard-coded policy.
- `0`: clears existing cache entries on every invocation.
- The exact age boundary and future mtimes are stale.
- Expiry clears the entire cache file; the existing update path then contacts providers and repopulates it.
- Any cache-content write refreshes the single file mtime for all entries. This is local cache expiry, not DNS TTL.

## Validation

- 926 unit tests passed on Python 3.11.9 (21 skipped).
- Ruff lint passed for the full repository.
- Ruff formatting passed for all changed Python files.
- GitHub checks passed for lint, documentation, CodeQL, PyPI, Python 2.7 and Python 3 through 3.14-dev, plus all Nuitka platform jobs.
- Added regression coverage for mtime boundaries, zero/future values, validation and precedence, environment loading, generated config, v4.1 inheritance/schema, scheduler propagation, and `run()` wiring.

## CI baseline note

The ARM glibc binary and ARM Docker jobs hit the existing Nuitka/Zstandard `Allocation error: not enough memory`. The same ARM glibc failure is present on the `master` baseline build (run 31004816605) and is unrelated to this Python/configuration change; ARM build remediation is tracked separately in #708.

## Scope

Shared custom-cache key collisions, desired-state fingerprints, and record-level freshness remain unchanged and out of scope.

Supersedes #691