### PR TITLE
fix(docker): prevent zombie process accumulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,6 +418,9 @@ jobs:
             docker run --platform $platform --rm -v "$(pwd):/ddns/" ${{ env.DOCKER_IMG }}:$tag -c /ddns/tests/config/debug.json -c /ddns/tests/config/noip.json
             docker run --platform $platform --rm -v "$(pwd):/ddns/" ${{ env.DOCKER_IMG }}:$tag -c https://ddns.newfuture.cc/tests/config/debug.json
             docker run --platform $platform --rm -v "$(pwd):/ddns/" ${{ env.DOCKER_IMG }}:$tag -c /ddns/tests/config/he-proxies.json
+            if [ "$platform" = "linux/amd64" ]; then
+              sh tests/scripts/test-docker-zombies.sh "${{ env.DOCKER_IMG }}:$tag" "$platform"
+            fi
           done
       
       # 上传测试结果和镜像

--- a/ddns/ip.py
+++ b/ddns/ip.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from re import compile
-from os import name as os_name, popen
+from os import name as os_name
 from socket import socket, getaddrinfo, gethostname, AF_INET, AF_INET6, SOCK_DGRAM
 from logging import debug, error
 
 from .util.http import request
+from .util.try_run import try_run
 
 # 模块级别的SSL验证配置，默认使用auto模式
 ssl_verify = "auto"
@@ -113,16 +114,23 @@ def public_v6(url=None, reg=IPV6_REG):  # 公网IPV6地址
         return _try_multiple_apis(PUBLIC_IPV6_APIS, reg, "IPv6")
 
 
+def _read_network_config():
+    # type: () -> str | None
+    if os_name == "nt":
+        return try_run(["ipconfig"])
+
+    output = try_run(["ip", "address"])
+    if output is None:
+        output = try_run(["ifconfig"])
+    return output
+
+
 def _ip_regex_match(parrent_regex, match_regex):
     ip_pattern = compile(parrent_regex)
     matcher = compile(match_regex)
 
-    if os_name == "nt":  # windows:
-        cmd = "ipconfig"
-    else:
-        cmd = "ip address || ifconfig 2>/dev/null"
-
-    for s in popen(cmd).readlines():
+    output = _read_network_config()
+    for s in (output or "").splitlines(True):
         addr = ip_pattern.search(s)
         if addr and matcher.match(addr.group(1)):
             return addr.group(1)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,7 @@ RUN mkdir /output && cp dist/ddns /output/
 COPY docker/entrypoint.sh /output/
 
 FROM alpine:${HOST_VERSION}
+RUN apk add --no-cache tini
 COPY --from=builder /output/* /bin/
 WORKDIR /ddns
-ENTRYPOINT [ "/bin/entrypoint.sh" ]
+ENTRYPOINT [ "/sbin/tini", "--", "/bin/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,4 +57,4 @@ FROM alpine:${HOST_VERSION}
 RUN apk add --no-cache tini
 COPY --from=builder /output/* /bin/
 WORKDIR /ddns
-ENTRYPOINT [ "/sbin/tini", "--", "/bin/entrypoint.sh" ]
+ENTRYPOINT [ "/sbin/tini", "-g", "--", "/bin/entrypoint.sh" ]

--- a/tests/scripts/test-docker-zombies.sh
+++ b/tests/scripts/test-docker-zombies.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# Verify that regex IP detection neither launches an intermediate shell nor
+# leaves zombie processes when crond is the container's PID 1.
+
+set -eu
+
+TEST_ROOT=/tmp/ddns-zombie-test
+TEST_BIN="$TEST_ROOT/bin"
+PARENT_LOG="$TEST_ROOT/ip-parents"
+READY_FILE="$TEST_ROOT/ready"
+
+setup_container() {
+    mkdir -p "$TEST_BIN"
+    cat > "$TEST_BIN/ip" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ] || [ "$1" != "address" ]; then
+    echo "Unexpected ip arguments: $*" >&2
+    exit 64
+fi
+
+cat "/proc/$PPID/comm" >> /tmp/ddns-zombie-test/ip-parents
+cat <<'EOF_IP_OUTPUT'
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
+    inet6 2001:db8::42/64 scope global
+EOF_IP_OUTPUT
+EOF
+    chmod 755 "$TEST_BIN/ip"
+    : > "$PARENT_LOG"
+    : > "$READY_FILE"
+}
+
+check_process_tree() {
+    init_name=$(cat /proc/1/comm)
+    if [ "$init_name" != "tini" ]; then
+        echo "Expected tini as PID 1, got $init_name" >&2
+        return 1
+    fi
+
+    crond_parent=$(ps -o pid,ppid,stat,comm | awk 'NR > 1 && $4 == "crond" { print $2; exit }')
+    if [ "$crond_parent" != "1" ]; then
+        echo "Expected crond to be a direct child of tini, got PPID ${crond_parent:-missing}" >&2
+        return 1
+    fi
+}
+
+check_container() {
+    expected_runs=$1
+    actual_runs=$(wc -l < "$PARENT_LOG")
+
+    check_process_tree
+
+    if [ "$actual_runs" -ne "$expected_runs" ]; then
+        echo "Expected $expected_runs ip executions, got $actual_runs" >&2
+        cat "$PARENT_LOG" >&2
+        exit 1
+    fi
+
+    if grep -Eq "^(sh|ash|busybox)$" "$PARENT_LOG"; then
+        echo "Regex IP detection launched ip through an intermediate shell" >&2
+        cat "$PARENT_LOG" >&2
+        exit 1
+    fi
+
+    zombies=$(ps -o pid,ppid,stat,comm | awk 'NR > 1 && $3 ~ /^Z/ { print }')
+    if [ -n "$zombies" ]; then
+        echo "Zombie processes found after regex IP detection:" >&2
+        echo "$zombies" >&2
+        exit 1
+    fi
+
+    echo "Regex IP detection completed $actual_runs runs without shell intermediates or zombies"
+}
+
+case "${1:-}" in
+    --setup)
+        setup_container
+        exit 0
+        ;;
+    --check)
+        check_container "$2"
+        exit 0
+        ;;
+    --ready)
+        test -f "$READY_FILE"
+        check_process_tree
+        exit 0
+        ;;
+esac
+
+image=${1:?Usage: test-docker-zombies.sh IMAGE [PLATFORM]}
+platform=${2:-linux/amd64}
+runs=${DDNS_ZOMBIE_TEST_RUNS:-8}
+script_dir=$(cd "$(dirname "$0")" && pwd)
+container="ddns-zombie-test-$$"
+
+cleanup() {
+    docker rm -f "$container" >/dev/null 2>&1 || true
+}
+trap cleanup 0 1 2 15
+
+expected_entrypoint='["/sbin/tini","--","/bin/entrypoint.sh"]'
+actual_entrypoint=$(docker image inspect --format '{{json .Config.Entrypoint}}' "$image")
+if [ "$actual_entrypoint" != "$expected_entrypoint" ]; then
+    echo "Unexpected image entrypoint: $actual_entrypoint" >&2
+    exit 1
+fi
+
+docker run --detach \
+    --name "$container" \
+    --platform "$platform" \
+    --entrypoint /sbin/tini \
+    --volume "$script_dir:/tests:ro" \
+    "$image" \
+    -- /bin/sh -c "/bin/sh /tests/test-docker-zombies.sh --setup; exec crond -f" >/dev/null
+
+attempt=0
+until docker exec "$container" /bin/sh /tests/test-docker-zombies.sh --ready 2>/dev/null; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 30 ]; then
+        echo "Timed out waiting for the zombie test container" >&2
+        docker logs "$container" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+test_path="$TEST_BIN:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+run=0
+while [ "$run" -lt "$runs" ]; do
+    output=$(docker exec --env "PATH=$test_path" "$container" \
+        /bin/ddns \
+        --dns=debug \
+        '--index6=regex:2001:db8:.*' \
+        --ipv6=zombie-test.example \
+        --cache=false)
+    if ! printf '%s\n' "$output" | grep -q '^\[IPv6\] 2001:db8::42$'; then
+        echo "Regex IPv6 result did not reach the debug provider:" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+    run=$((run + 1))
+done
+
+sleep 1
+docker exec "$container" /bin/sh /tests/test-docker-zombies.sh --check "$runs"
+
+docker stop --time 5 "$container" >/dev/null
+exit_code=$(docker inspect --format '{{.State.ExitCode}}' "$container")
+if [ "$exit_code" -eq 137 ]; then
+    echo "Container required SIGKILL instead of a graceful Tini shutdown" >&2
+    exit 1
+fi
+echo "Tini forwarded shutdown with container exit code $exit_code"

--- a/tests/scripts/test-docker-zombies.sh
+++ b/tests/scripts/test-docker-zombies.sh
@@ -4,6 +4,14 @@
 
 set -eu
 
+if [ "${DDNS_SIGNAL_TEST_IP:-}" = "1" ]; then
+    trap ': > /signal/terminated; exit 0' TERM INT
+    : > /signal/started
+    while :; do
+        sleep 1
+    done
+fi
+
 TEST_ROOT=/tmp/ddns-zombie-test
 TEST_BIN="$TEST_ROOT/bin"
 PARENT_LOG="$TEST_ROOT/ip-parents"
@@ -73,6 +81,45 @@ check_container() {
     echo "Regex IP detection completed $actual_runs runs without shell intermediates or zombies"
 }
 
+test_startup_signal_forwarding() {
+    docker run --detach \
+        --name "$signal_container" \
+        --platform "$platform" \
+        --env "PATH=/tmp:$base_path" \
+        --env DDNS_DNS=debug \
+        --env DDNS_IPV6=zombie-test.example \
+        --env 'DDNS_INDEX6=regex:2001:db8:.*' \
+        --env DDNS_CACHE=false \
+        --env DDNS_SIGNAL_TEST_IP=1 \
+        --volume "$script_path:/tmp/ip:ro" \
+        --volume "$signal_dir:/signal" \
+        "$image" >/dev/null
+
+    attempt=0
+    until [ -f "$signal_dir/started" ]; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge 30 ]; then
+            echo "Timed out waiting for the initial DDNS update" >&2
+            docker logs "$signal_container" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    docker stop --time 5 "$signal_container" >/dev/null
+    if [ ! -f "$signal_dir/terminated" ]; then
+        echo "Tini did not forward SIGTERM to the initial DDNS process group" >&2
+        exit 1
+    fi
+
+    exit_code=$(docker inspect --format '{{.State.ExitCode}}' "$signal_container")
+    if [ "$exit_code" -eq 137 ]; then
+        echo "Initial DDNS shutdown required SIGKILL" >&2
+        exit 1
+    fi
+    echo "Tini forwarded SIGTERM during the initial DDNS update"
+}
+
 case "${1:-}" in
     --setup)
         setup_container
@@ -93,14 +140,21 @@ image=${1:?Usage: test-docker-zombies.sh IMAGE [PLATFORM]}
 platform=${2:-linux/amd64}
 runs=${DDNS_ZOMBIE_TEST_RUNS:-8}
 script_dir=$(cd "$(dirname "$0")" && pwd)
+script_path="$script_dir/$(basename "$0")"
 container="ddns-zombie-test-$$"
+signal_container="${container}-signal"
+signal_dir="${TMPDIR:-/tmp}/${signal_container}"
+base_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+mkdir -p "$signal_dir"
 
 cleanup() {
     docker rm -f "$container" >/dev/null 2>&1 || true
+    docker rm -f "$signal_container" >/dev/null 2>&1 || true
+    rm -rf "$signal_dir"
 }
 trap cleanup 0 1 2 15
 
-expected_entrypoint='["/sbin/tini","--","/bin/entrypoint.sh"]'
+expected_entrypoint='["/sbin/tini","-g","--","/bin/entrypoint.sh"]'
 actual_entrypoint=$(docker image inspect --format '{{json .Config.Entrypoint}}' "$image")
 if [ "$actual_entrypoint" != "$expected_entrypoint" ]; then
     echo "Unexpected image entrypoint: $actual_entrypoint" >&2
@@ -113,7 +167,7 @@ docker run --detach \
     --entrypoint /sbin/tini \
     --volume "$script_dir:/tests:ro" \
     "$image" \
-    -- /bin/sh -c "/bin/sh /tests/test-docker-zombies.sh --setup; exec crond -f" >/dev/null
+    -g -- /bin/sh -c "/bin/sh /tests/test-docker-zombies.sh --setup; exec crond -f" >/dev/null
 
 attempt=0
 until docker exec "$container" /bin/sh /tests/test-docker-zombies.sh --ready 2>/dev/null; do
@@ -126,7 +180,7 @@ until docker exec "$container" /bin/sh /tests/test-docker-zombies.sh --ready 2>/
     sleep 1
 done
 
-test_path="$TEST_BIN:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+test_path="$TEST_BIN:$base_path"
 run=0
 while [ "$run" -lt "$runs" ]; do
     output=$(docker exec --env "PATH=$test_path" "$container" \
@@ -153,3 +207,5 @@ if [ "$exit_code" -eq 137 ]; then
     exit 1
 fi
 echo "Tini forwarded shutdown with container exit code $exit_code"
+
+test_startup_signal_forwarding

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -258,11 +258,79 @@ class TestIpModule(unittest.TestCase):
         self.assertEqual(result, "1.2.3.4")
         self.assertEqual(mock_request.call_count, len(ip.PUBLIC_IPV4_APIS) + 1)
 
+    @patch("ddns.ip.os_name", "posix")
+    @patch("ddns.ip.try_run")
+    def test_regex_v4_uses_ip_address(self, mock_try_run):
+        """测试Unix IPv4正则通过参数列表执行ip命令"""
+        mock_try_run.return_value = "2: eth0\n    inet 192.0.2.10/24 scope global eth0\n"
+
+        result = ip.regex_v4(r"192\.0\.2\..*")
+
+        self.assertEqual(result, "192.0.2.10")
+        mock_try_run.assert_called_once_with(["ip", "address"])
+
+    @patch("ddns.ip.os_name", "posix")
+    @patch("ddns.ip.try_run")
+    def test_regex_v6_uses_ip_address(self, mock_try_run):
+        """测试Unix IPv6正则通过参数列表执行ip命令"""
+        mock_try_run.return_value = "2: eth0\n    inet6 2409:8a00::1/64 scope global\n"
+
+        result = ip.regex_v6(r"2409:.*")
+
+        self.assertEqual(result, "2409:8a00::1")
+        mock_try_run.assert_called_once_with(["ip", "address"])
+
+    @patch("ddns.ip.os_name", "posix")
+    @patch("ddns.ip.try_run")
+    def test_regex_falls_back_to_ifconfig_when_ip_fails(self, mock_try_run):
+        """测试ip命令失败时直接执行ifconfig"""
+        mock_try_run.side_effect = [None, "inet addr:198.51.100.7 Mask:255.255.255.0\n"]
+
+        result = ip.regex_v4(r"198\.51\.100\..*")
+
+        self.assertEqual(result, "198.51.100.7")
+        self.assertEqual(mock_try_run.call_args_list[0][0][0], ["ip", "address"])
+        self.assertEqual(mock_try_run.call_args_list[1][0][0], ["ifconfig"])
+
+    @patch("ddns.ip.os_name", "posix")
+    @patch("ddns.ip.try_run")
+    def test_regex_does_not_fallback_after_successful_ip_command(self, mock_try_run):
+        """测试ip命令成功但不匹配时不执行ifconfig"""
+        mock_try_run.return_value = "2: eth0\n    inet 192.0.2.10/24 scope global eth0\n"
+
+        result = ip.regex_v4(r"172\.16\..*")
+
+        self.assertIsNone(result)
+        mock_try_run.assert_called_once_with(["ip", "address"])
+
+    @patch("ddns.ip.os_name", "posix")
+    @patch("ddns.ip.try_run")
+    def test_regex_returns_none_when_network_commands_fail(self, mock_try_run):
+        """测试ip和ifconfig均失败时返回空结果"""
+        mock_try_run.side_effect = [None, None]
+
+        result = ip.regex_v4(r".*")
+
+        self.assertIsNone(result)
+        self.assertEqual(mock_try_run.call_count, 2)
+
+    @patch("ddns.ip.os_name", "nt")
+    @patch("ddns.ip.try_run")
+    def test_regex_v4_uses_ipconfig_on_windows(self, mock_try_run):
+        """测试Windows IPv4正则直接执行ipconfig"""
+        mock_try_run.return_value = "IPv4 Address. . . . . . . . . . . : 203.0.113.9\r\n"
+
+        result = ip.regex_v4(r"203\.0\.113\..*")
+
+        self.assertEqual(result, "203.0.113.9")
+        mock_try_run.assert_called_once_with(["ipconfig"])
+
     @patch("ddns.ip.public_v4")
-    @patch("ddns.ip.popen")
-    def test_get_ip_regex_rule_fallback(self, mock_popen, mock_public_v4):
+    @patch("ddns.ip.os_name", "posix")
+    @patch("ddns.ip.try_run")
+    def test_get_ip_regex_rule_fallback(self, mock_try_run, mock_public_v4):
         """测试regex规则返回空结果时继续回退"""
-        mock_popen.return_value.readlines.return_value = ["inet 192.168.1.10/24", "inet 10.0.0.2/24"]
+        mock_try_run.return_value = "inet 192.168.1.10/24\ninet 10.0.0.2/24\n"
         mock_public_v4.return_value = "1.2.3.4"
 
         result = get_ip("4", ["regex:172\\.16\\..*", "public"])


### PR DESCRIPTION
## Summary
- replace shell-based regex IP detection with direct, fully waited subprocess calls while preserving `ip` to `ifconfig` fallback behavior
- run Alpine containers under Tini so PID 1 reaps orphaned children and forwards shutdown signals
- add unit coverage plus an image-level regression that checks the Tini/crond process tree, repeated IPv6 regex lookups, and zombie cleanup

## Validation
- `python -m unittest tests.test_ip -v`
- `python -m unittest discover tests -v` (932 tests, 21 skipped)
- Ruff checks and formatting
- ShellCheck and actionlint

The Docker image regression runs in CI because this host does not provide Docker or Podman.

Closes #677