### PR TITLE
docs(agents): separate Config Studio from LLM sources

### DIFF
--- a/.github/prompts/issue-assistant.md
+++ b/.github/prompts/issue-assistant.md
@@ -36,6 +36,8 @@ Request the files you need to obtain the details.
 
 - Three-level config priority: CLI args > JSON config files > environment variables.
 
+- Interactive Config Studio: direct users to https://ddns.newfuture.cc/config/studio.html to build and validate configurations in the browser. Do not request `docs/config/studio.md` or `docs/en/config/studio.md`; they are UI entry pages, not Q&A source material.
+
 - Multiple IP detection methods (`ddns.ip`):  
   network interface index / default route IP / public IP via API / custom URL / regex on ifconfig output / custom command or shell  
 

--- a/.github/scripts/issue-ai-response.js
+++ b/.github/scripts/issue-ai-response.js
@@ -10,6 +10,10 @@
 module.exports = async ({ github, context, core, fs, path }) => {
   const apiUrl = process.env.OPENAI_URL;
   const apiKey = process.env.OPENAI_KEY;
+  const excludedQAFiles = new Set([
+    path.resolve(process.cwd(), 'docs/config/studio.md'),
+    path.resolve(process.cwd(), 'docs/en/config/studio.md')
+  ]);
 
   if (!apiUrl || !apiKey) {
     core.setFailed('OPENAI_URL and OPENAI_KEY must be set');
@@ -68,6 +72,9 @@ module.exports = async ({ github, context, core, fs, path }) => {
       const fullPath = path.resolve(repoRoot, filePath);
       if (path.relative(repoRoot, fullPath).startsWith('..')) {
         return '[Access denied: ' + filePath + ']';
+      }
+      if (excludedQAFiles.has(fullPath)) {
+        return '[Excluded from Q&A source context: ' + filePath + ']';
       }
       if (!fs.existsSync(fullPath)) {
         return '[File not found: ' + filePath + ']';

--- a/.github/scripts/update_agents_structure.py
+++ b/.github/scripts/update_agents_structure.py
@@ -15,8 +15,15 @@ ENGLISH_MIRROR_DIRS = ("docs/en/config", "docs/en/dev", "docs/en/providers")
 def scan_files(directory, extensions):
     # type: (str, tuple) -> set
     """Scan directory for files with given extensions."""
-    # Files to exclude from directory structure tracking
-    exclude_files = {"docs/esa-deploy.md", "docs/esa.js", "docs/llms.txt", "docs/package.json"}
+    # Files to exclude from the agent and Q&A directory index
+    exclude_files = {
+        "docs/config/studio.md",
+        "docs/en/config/studio.md",
+        "docs/esa-deploy.md",
+        "docs/esa.js",
+        "docs/llms.txt",
+        "docs/package.json",
+    }
 
     result = set()
     base = os.path.join(REPO_ROOT, directory)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,6 +424,6 @@ For detailed information on specific topics, refer to:
 
 ---
 
-**Version**: 1.0.6
-**Last Updated**: 2026-06-15
+**Version**: 1.0.7
+**Last Updated**: 2026-08-10
 **Maintained by**: DDNS Project Contributors

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,7 +24,7 @@ DDNS is a Python-based dynamic DNS client that automatically updates DNS records
 
 ## Documentation Structure
 
-**Note:** All documentation is available in both HTML and Markdown formats. 
+**Note:** Documentation guides are available in both HTML and Markdown formats; interactive tools are HTML-only.
 - HTML: For web browsers (e.g., `/install.html`)
 - Markdown: For AI/LLM consumption (e.g., `/install.md`)
 - English docs mirror the Chinese paths with the `/en/` prefix (e.g., `/en/install.md`, `/en/config/json.md`, `/en/providers/cloudflare.md`).
@@ -39,6 +39,7 @@ DDNS is a Python-based dynamic DNS client that automatically updates DNS records
 - CLI Arguments: https://ddns.newfuture.cc/config/cli ([.md](https://ddns.newfuture.cc/config/cli.md))
 - Environment Variables: https://ddns.newfuture.cc/config/env ([.md](https://ddns.newfuture.cc/config/env.md))
 - JSON Configuration: https://ddns.newfuture.cc/config/json ([.md](https://ddns.newfuture.cc/config/json.md))
+- Interactive Config Studio: https://ddns.newfuture.cc/config/studio.html (build and validate DDNS configurations in the browser)
 
 ### DNS Provider Guides
 - Provider Overview: https://ddns.newfuture.cc/providers/ ([.md](https://ddns.newfuture.cc/providers/README.md))


### PR DESCRIPTION
## Summary

- advertise Config Studio in the public `llms.txt` through its interactive HTML page only
- exclude the Studio Markdown wrappers from the `AGENTS.md`/Issue Q&A directory index
- prevent the Q&A action from reading either language's Studio Markdown while directing users to the browser tool
- update the AGENTS guide metadata to version 1.0.7

## Validation

- `uv run --no-project --python 3.13 .github/scripts/update_agents_structure.py`
- mocked Issue Q&A request for both excluded Markdown files
- `node --check .github/scripts/issue-ai-response.js`
- `ruff check` and `ruff format --check` for the modified Python script
- `git diff --check`

Closes #713