### PR TITLE
docs(agents): document embedded web package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,12 @@ ddns/:	Main application code
 		http.py:	HTTP client with proxy support
 		try_run.py:	Safe command execution
 
+	web/:	Embedded management dashboard
+		__init__.py:	Dashboard package exports
+		scheduler.py:	In-process dashboard synchronization scheduler
+		server.py:	Local-only embedded dashboard HTTP server
+		service.py:	Dashboard data and configuration services
+
 tests/:	Unit tests
 	__init__.py:	Test initialization (path setup)
 	base_test.py:	Shared test utilities and base classes
@@ -424,6 +430,6 @@ For detailed information on specific topics, refer to:
 
 ---
 
-**Version**: 1.0.7
-**Last Updated**: 2026-08-10
+**Version**: 1.0.8
+**Last Updated**: 2026-08-12
 **Maintained by**: DDNS Project Contributors


### PR DESCRIPTION
`AGENTS.md` did not include the embedded dashboard modules under `ddns/web`, leaving the agent guide out of sync with the repository.

- Add the four `ddns/web` modules with concise role descriptions.
- Bump the guide version to `1.0.8` and update its date to `2026-08-12`.

Fixes: #720