### PR TITLE
feat(mcp): add dependency-free DDNS server

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -111,6 +111,14 @@ ddns -c config.json --interval 5 --open
 
 Providing `--interval` automatically selects Web mode, so the `web` word is optional. You can also set top-level `"interval": 5` in a local JSON file; then `ddns -c config.json` starts Web automatically. The command-line value overrides the configuration, and the existing `ddns web` command remains compatible. Saving a new interval in the page writes it back to the configuration; pausing and resuming affect only the current process. Web mode blocks duplicate scheduling when an enabled system task is detected. Use systemd, launchd, a Windows service, or Docker to supervise the Web process in production.
 
+Let a local MCP client such as GitHub Copilot inspect cached status or trigger one complete synchronization after user approval:
+
+```bash
+ddns mcp -c /etc/ddns/config.json
+```
+
+This stdio server uses only the Python standard library, opens no network listener, and does not expose configuration credentials to the model. It supports MCP `2026-07-28` and the `2025-11-25` lifecycle used by GitHub Copilot CLI. See the [MCP command documentation](docs/en/config/cli.md#mcp-server) for client setup, tools, and limitations.
+
 For a headless deployment, install a system task that runs every five minutes:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ ddns -c config.json --interval 5 --open
 
 提供 `--interval` 会自动进入 Web 模式，无需额外写 `web`；也可在本地 JSON 顶层配置 `"interval": 5`，此时 `ddns -c config.json` 会自动启动 Web。命令行值优先于配置，原有 `ddns web` 命令继续兼容。页面保存的新间隔会写回配置；暂停和恢复只影响当前进程。检测到已启用的系统任务时，Web 会阻止重复调度。生产环境应使用 systemd、launchd、Windows 服务或 Docker 负责 Web 进程保活。
 
+让 GitHub Copilot 等本机 MCP 客户端查询缓存状态，或在人工确认后触发一次完整同步：
+
+```bash
+ddns mcp -c /etc/ddns/config.json
+```
+
+该 stdio 服务只使用 Python 标准库，不监听网络，也不会向模型暴露配置凭据；支持 MCP `2026-07-28`，并兼容 GitHub Copilot CLI 使用的 `2025-11-25`。具体客户端配置、工具与限制见 [MCP 命令文档](docs/config/cli.md#mcp-服务)。
+
 不需要 Web 控制台时，可以安装每 5 分钟执行一次的系统定时任务：
 
 ```bash

--- a/ddns/__main__.py
+++ b/ddns/__main__.py
@@ -118,13 +118,14 @@ def run(config):
 
 def main():
     stdout = sys.stdout  # pythonw 模式无 stdout
+    mcp_mode = len(sys.argv) > 1 and sys.argv[1] == "mcp"
     if stdout and stdout.encoding and stdout.encoding.lower() != "utf-8" and hasattr(stdout, "buffer"):
         # 兼容windows 和部分ASCII编码的老旧系统
         sys.stdout = TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
         sys.stderr = TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
     # Windows 下输出一个空行
-    if stdout and sys.platform.startswith("win"):
+    if stdout and sys.platform.startswith("win") and not mcp_mode:
         stdout.write("\r\n")
 
     logger.name = "ddns"

--- a/ddns/__main__.py
+++ b/ddns/__main__.py
@@ -18,6 +18,16 @@ from .provider import SimpleProvider, get_provider_class  # noqa: F401
 logger = getLogger()
 
 
+class UpdateCancelled(Exception):
+    """Raised when a caller cancels an in-progress DDNS update."""
+
+
+def _raise_if_cancelled(cancelled):
+    # type: (object | None) -> None
+    if cancelled is not None and cancelled():
+        raise UpdateCancelled("DDNS update cancelled.")
+
+
 def _get_ip_from_rule(ip_type, rule):
     """
     Resolve an IP address from a single rule.
@@ -36,13 +46,14 @@ def _get_ip_from_rule(ip_type, rule):
     return getattr(ip, rule_text + "_v" + ip_type)()
 
 
-def get_ip(ip_type, rules):
+def get_ip(ip_type, rules, cancelled=None):
     """
     get IP address
     """
     if rules is False:  # disabled
         return False
     for rule in rules:
+        _raise_if_cancelled(cancelled)
         try:
             logger.debug("get_ip:(%s, %s)", ip_type, rule)
             result = _get_ip_from_rule(ip_type, rule)
@@ -50,6 +61,7 @@ def get_ip(ip_type, rules):
             logger.error("Failed to get %s address: %s", ip_type, e)
             continue
 
+        _raise_if_cancelled(cancelled)
         if result:
             return result
 
@@ -57,16 +69,17 @@ def get_ip(ip_type, rules):
     return None
 
 
-def update_ip(dns, cache, index_rule, domains, record_type, config):
-    # type: (SimpleProvider, Cache | None, list[str]|bool, list[str], str, Config) -> bool | None
+def update_ip(dns, cache, index_rule, domains, record_type, config, cancelled=None):
+    # type: (SimpleProvider, Cache | None, list[str]|bool, list[str], str, Config, object | None) -> bool | None
     """
     更新IP并变更DNS记录
     """
+    _raise_if_cancelled(cancelled)
     if not domains:
         return None
 
     ip_type = "4" if record_type == "A" else "6"
-    address = get_ip(ip_type, index_rule)
+    address = get_ip(ip_type, index_rule, cancelled=cancelled)
     if not address:
         logger.error("Fail to get %s address!", ip_type)
         return False
@@ -74,6 +87,7 @@ def update_ip(dns, cache, index_rule, domains, record_type, config):
     update_success = False
 
     for domain in domains:
+        _raise_if_cancelled(cancelled)
         domain = domain.lower()
         cache_key = "{}:{}".format(domain, record_type)
         if cache and cache.get(cache_key) == address:
@@ -93,11 +107,12 @@ def update_ip(dns, cache, index_rule, domains, record_type, config):
                     logger.error("Failed to update %s record for %s", record_type, domain)
             except Exception as e:
                 logger.exception("Failed to update %s record for %s: %s", record_type, domain, e)
+    _raise_if_cancelled(cancelled)
     return update_success
 
 
-def run(config):
-    # type: (Config) -> bool
+def run(config, cancelled=None):
+    # type: (Config, object | None) -> bool
     """
     Run the DDNS update process
     """
@@ -111,8 +126,8 @@ def run(config):
     )
     cache = Cache.new(config.cache, config.md5(), logger, config.cache_max_age)
     return (
-        update_ip(dns, cache, config.index4, config.ipv4, "A", config) is not False
-        and update_ip(dns, cache, config.index6, config.ipv6, "AAAA", config) is not False
+        update_ip(dns, cache, config.index4, config.ipv4, "A", config, cancelled=cancelled) is not False
+        and update_ip(dns, cache, config.index6, config.ipv6, "AAAA", config, cancelled=cancelled) is not False
     )
 
 

--- a/ddns/config/cli.py
+++ b/ddns/config/cli.py
@@ -303,6 +303,14 @@ def _add_web_subcommand(subparsers):
     )
 
 
+def _add_mcp_subcommand(subparsers):
+    # type: (object) -> None
+    """Add the local stdio MCP server command."""
+    mcp = subparsers.add_parser("mcp", help="Run the local MCP server [运行本机 MCP 服务]")
+    mcp.set_defaults(func=_handle_mcp_command)
+    mcp.add_argument("-c", "--config", metavar="FILE", help="local config file [本机配置文件]")
+
+
 def _add_task_subcommand_if_needed(parser):  # type: (ArgumentParser) -> None
     """
     Conditionally add subcommands to avoid Python 2 'too few arguments' error.
@@ -317,12 +325,13 @@ def _add_task_subcommand_if_needed(parser):  # type: (ArgumentParser) -> None
     subparsers = parser.add_subparsers(dest="command", help="subcommands [子命令]")
     _add_task_subcommand(subparsers)
     _add_web_subcommand(subparsers)
+    _add_mcp_subcommand(subparsers)
 
 
 def _expand_web_interval_shorthand():
     # type: () -> None
     """Treat a top-level --interval option as an implicit web command."""
-    if len(sys.argv) <= 1 or sys.argv[1] in ("task", "web"):
+    if len(sys.argv) <= 1 or sys.argv[1] in ("task", "web", "mcp"):
         return
     if any(argument == "--interval" or argument.startswith("--interval=") for argument in sys.argv[1:]):
         config_paths = _cli_config_paths(sys.argv[1:])
@@ -414,6 +423,16 @@ def _validate_explicit_web_configs():
         _reject_multiple_web_configs()
 
 
+def _validate_explicit_mcp_configs():
+    # type: () -> None
+    if len(sys.argv) <= 1 or sys.argv[1] != "mcp":
+        return
+    config_paths = _cli_config_paths(sys.argv[2:])
+    if config_paths is not None and len(config_paths) != 1:
+        sys.stderr.write("ddns mcp: exactly one local configuration file is supported.\n")
+        sys.exit(2)
+
+
 def _validate_web_mode_arguments():
     # type: () -> None
     if len(sys.argv) <= 1 or sys.argv[1] != "web":
@@ -437,11 +456,31 @@ def _validate_web_mode_arguments():
         sys.exit(2)
 
 
+def _validate_mcp_mode_arguments():
+    # type: () -> None
+    if len(sys.argv) <= 1 or sys.argv[1] != "mcp":
+        return
+    value_options = ("-c", "--config")
+    long_value_prefixes = ("--config=",)
+    arguments = sys.argv[2:]
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument in value_options:
+            index += 2
+            continue
+        if argument in ("-h", "--help") or argument.startswith(long_value_prefixes):
+            index += 1
+            continue
+        sys.stderr.write("ddns mcp: unsupported option {}.\n".format(argument))
+        sys.exit(2)
+
+
 def _expand_web_config_shorthand():
     # type: () -> None
     arguments = sys.argv[1:]
     if (
-        (arguments and arguments[0] in ("task", "web"))
+        (arguments and arguments[0] in ("task", "web", "mcp"))
         or any(argument in ("-h", "--help", "-v", "--version", "--new-config") for argument in arguments)
         or any(argument.startswith("--new-config=") for argument in arguments)
     ):
@@ -477,7 +516,9 @@ def load_config(description, doc, version, date):
     _expand_web_interval_shorthand()
     _expand_web_config_shorthand()
     _validate_explicit_web_configs()
+    _validate_explicit_mcp_configs()
     _validate_web_mode_arguments()
+    _validate_mcp_mode_arguments()
     parser = ArgumentParser(description=description, epilog=doc, formatter_class=RawTextHelpFormatter)
     sysinfo = _get_system_info_str()
     pyinfo = _get_python_info_str()
@@ -605,10 +646,9 @@ def _handle_task_command(args):  # type: (dict) -> None
             sys.exit(1)
 
 
-def _handle_web_command(args):
-    # type: (dict) -> None
-    """Run the local-only embedded management dashboard."""
-    basicConfig(level=args.get("debug") and DEBUG or args.get("log_level", "INFO"))
+def _local_config_path(args, command):
+    # type: (dict, str) -> str | None
+    """Resolve one local config path shared by long-running local services."""
     config_path = args.get("config")
     if not config_path:
         config_path = load_env_config().get("config")
@@ -619,12 +659,20 @@ def _handle_web_command(args):
 
         config_paths = split_array_string(config_path, preserve_special=False)
         if len(config_paths) != 1:
-            sys.stderr.write("ddns web: exactly one local configuration file is supported.\n")
+            sys.stderr.write("ddns {}: exactly one local configuration file is supported.\n".format(command))
             sys.exit(2)
         config_path = config_paths[0]
         if "://" in config_path:
-            sys.stderr.write("ddns web: remote configuration files are not supported.\n")
+            sys.stderr.write("ddns {}: remote configuration files are not supported.\n".format(command))
             sys.exit(2)
+    return config_path
+
+
+def _handle_web_command(args):
+    # type: (dict) -> None
+    """Run the local-only embedded management dashboard."""
+    basicConfig(level=args.get("debug") and DEBUG or args.get("log_level", "INFO"))
+    config_path = _local_config_path(args, "web")
 
     interval = args.get("interval")
     interval_from_config = False
@@ -651,3 +699,14 @@ def _handle_web_command(args):
         logger=getLogger(),
         interval=interval,
     )
+
+
+def _handle_mcp_command(args):
+    # type: (dict) -> None
+    """Run the local stdio MCP server."""
+    basicConfig()
+    config_path = _local_config_path(args, "mcp")
+
+    from ..mcp import serve
+
+    serve(config_path=config_path)

--- a/ddns/mcp.py
+++ b/ddns/mcp.py
@@ -1,0 +1,416 @@
+# -*- coding: utf-8 -*-
+"""Minimal MCP server for local DDNS status and synchronization."""
+
+from __future__ import unicode_literals
+
+import json
+import logging
+import sys
+import threading
+
+try:
+    from queue import Queue
+except ImportError:  # Python 2
+    from Queue import Queue
+
+from . import __version__
+from .web.service import DashboardError, DashboardService
+
+try:
+    string_types = (basestring,)  # type: ignore[name-defined]
+    integer_types = (int, long)  # type: ignore[name-defined]
+    text_type = unicode  # type: ignore[name-defined]
+except NameError:
+    string_types = (str,)
+    integer_types = (int,)
+    text_type = str
+
+
+PROTOCOL_VERSION = "2026-07-28"
+LEGACY_PROTOCOL_VERSION = "2025-11-25"
+SUPPORTED_PROTOCOL_VERSIONS = (PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION)
+SERVER_NAME = "ddns"
+SERVER_INFO_KEY = "io.modelcontextprotocol/serverInfo"
+PROTOCOL_VERSION_KEY = "io.modelcontextprotocol/protocolVersion"
+CLIENT_CAPABILITIES_KEY = "io.modelcontextprotocol/clientCapabilities"
+CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo"
+STATUS_FIELDS = ("state", "message", "last_sync", "addresses", "providers", "records")
+
+EMPTY_INPUT_SCHEMA = {"type": "object", "additionalProperties": False}
+TOOLS = (
+    {
+        "name": "get_ddns_status",
+        "title": "Get DDNS status",
+        "description": "Read configured providers, cached DNS records, addresses, and the latest local sync status.",
+        "inputSchema": EMPTY_INPUT_SCHEMA,
+        "annotations": {
+            "title": "Get DDNS status",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    },
+    {
+        "name": "update_dns_records",
+        "title": "Update DNS records",
+        "description": "Run one complete DDNS synchronization for every record in the configured local file.",
+        "inputSchema": EMPTY_INPUT_SCHEMA,
+        "annotations": {
+            "title": "Update DNS records",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
+    },
+)
+_END_OF_INPUT = object()
+
+
+def _error_response(request_id, code, message, data=None):
+    # type: (object, int, str, object | None) -> dict
+    error = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": error}
+
+
+class McpServer(object):
+    """Handle modern MCP requests and the Copilot-compatible legacy lifecycle."""
+
+    def __init__(self, config_path=None, logger=None, service_factory=DashboardService):
+        # type: (str | None, logging.Logger | None, object) -> None
+        self.config_path = config_path
+        self.logger = (logger or logging.getLogger()).getChild("mcp")
+        self._service_factory = service_factory
+        self._cancelled = set()
+        self._pending = set()
+        self._cancel_lock = threading.Lock()
+        self._legacy_initialized = False
+        self._legacy_ready = False
+
+    @staticmethod
+    def _server_meta():
+        # type: () -> dict
+        return {SERVER_INFO_KEY: {"name": SERVER_NAME, "version": __version__}}
+
+    def _complete_result(self, result, modern=True):
+        # type: (dict, bool) -> dict
+        if modern:
+            result["resultType"] = "complete"
+            result["_meta"] = self._server_meta()
+        return result
+
+    def _discover(self):
+        # type: () -> dict
+        return self._complete_result(
+            {
+                "supportedVersions": list(SUPPORTED_PROTOCOL_VERSIONS),
+                "capabilities": {"tools": {}},
+                "instructions": (
+                    "Use get_ddns_status to inspect local cached state. "
+                    "Use update_dns_records only with user approval to update configured DNS records."
+                ),
+                "ttlMs": 3600000,
+                "cacheScope": "public",
+            }
+        )
+
+    def _list_tools(self, params, modern):
+        # type: (dict, bool) -> dict
+        if params.get("cursor") is not None:
+            raise ValueError("Pagination cursor is not supported.")
+        result = {"tools": list(TOOLS)}
+        if modern:
+            result.update({"ttlMs": 3600000, "cacheScope": "public"})
+        return self._complete_result(result, modern=modern)
+
+    @staticmethod
+    def _status_view(status):
+        # type: (dict) -> dict
+        return {field: status.get(field) for field in STATUS_FIELDS}
+
+    def _new_service(self):
+        # type: () -> DashboardService
+        return self._service_factory(config_path=self.config_path, logger=self.logger)
+
+    def _tool_success(self, status, modern):
+        # type: (dict, bool) -> dict
+        status = self._status_view(status)
+        text = json.dumps(status, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return self._complete_result(
+            {"content": [{"type": "text", "text": text}], "structuredContent": status, "isError": False}, modern=modern
+        )
+
+    def _tool_error(self, error, modern):
+        # type: (Exception, bool) -> dict
+        return self._complete_result(
+            {"content": [{"type": "text", "text": text_type(error)}], "isError": True}, modern=modern
+        )
+
+    def _call_tool(self, params, modern):
+        # type: (dict, bool) -> dict
+        name = params.get("name")
+        arguments = params.get("arguments", {})
+        if not isinstance(name, string_types):
+            raise ValueError("Tool name must be a string.")
+        if not isinstance(arguments, dict):
+            raise ValueError("Tool arguments must be an object.")
+        if arguments:
+            raise ValueError("This tool does not accept arguments.")
+        if name not in ("get_ddns_status", "update_dns_records"):
+            raise ValueError("Unknown tool: {}".format(name))
+
+        try:
+            service = self._new_service()
+            if name == "get_ddns_status":
+                return self._tool_success(service.dashboard(), modern=modern)
+            protocol_stdout = sys.stdout
+            try:
+                sys.stdout = sys.stderr
+                status = service.sync(source="MCP")
+            finally:
+                sys.stdout = protocol_stdout
+            return self._tool_success(status, modern=modern)
+        except DashboardError as error:
+            return self._tool_error(error, modern=modern)
+
+    def _dispatch(self, method, params, modern):
+        # type: (str, dict, bool) -> dict | None
+        if method == "server/discover":
+            return self._discover() if modern else None
+        if method == "tools/list":
+            return self._list_tools(params, modern=modern)
+        if method == "tools/call":
+            return self._call_tool(params, modern=modern)
+        if method == "ping" and not modern:
+            return {}
+        return None
+
+    def _initialize_legacy(self, params):
+        # type: (dict) -> dict
+        if not isinstance(params.get("protocolVersion"), string_types):
+            raise ValueError("protocolVersion is required.")
+        if not isinstance(params.get("capabilities"), dict):
+            raise ValueError("capabilities must be an object.")
+        client_info = params.get("clientInfo")
+        if (
+            not isinstance(client_info, dict)
+            or not isinstance(client_info.get("name"), string_types)
+            or not isinstance(client_info.get("version"), string_types)
+        ):
+            raise ValueError("clientInfo must contain string name and version fields.")
+        self._legacy_initialized = True
+        self._legacy_ready = False
+        return {
+            "protocolVersion": LEGACY_PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": self._server_meta()[SERVER_INFO_KEY],
+            "instructions": (
+                "Use get_ddns_status to inspect local cached state. "
+                "Use update_dns_records only with user approval to update configured DNS records."
+            ),
+        }
+
+    def _dispatch_response(self, request_id, method, params, modern):
+        # type: (object, str, dict, bool) -> dict
+        try:
+            result = self._dispatch(method, params, modern=modern)
+            if result is None:
+                return _error_response(request_id, -32601, "Method not found")
+        except ValueError as error:
+            return _error_response(request_id, -32602, text_type(error))
+        except Exception:
+            self.logger.exception("Unhandled MCP request failure")
+            return _error_response(request_id, -32603, "Internal error")
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    def _handle_legacy_request(self, request_id, method, params):
+        # type: (object, str, dict) -> dict
+        if method == "initialize":
+            try:
+                result = self._initialize_legacy(params)
+            except ValueError as error:
+                return _error_response(request_id, -32602, text_type(error))
+            return {"jsonrpc": "2.0", "id": request_id, "result": result}
+        if not self._legacy_ready and method != "ping":
+            return _error_response(request_id, -32600, "Server is not initialized")
+        return self._dispatch_response(request_id, method, params, modern=False)
+
+    def _handle_modern_request(self, request_id, method, params):
+        # type: (object, str, dict) -> dict
+        if method == "server/discover" and not isinstance(params.get("_meta"), dict):
+            return _error_response(request_id, -32601, "Method not found")
+        try:
+            meta = self._validate_meta(params)
+        except ValueError as error:
+            return _error_response(request_id, -32602, text_type(error))
+        requested_version = meta[PROTOCOL_VERSION_KEY]
+        if requested_version != PROTOCOL_VERSION:
+            return _error_response(
+                request_id,
+                -32022,
+                "Unsupported protocol version",
+                {"supported": list(SUPPORTED_PROTOCOL_VERSIONS), "requested": requested_version},
+            )
+        return self._dispatch_response(request_id, method, params, modern=True)
+
+    @staticmethod
+    def _request_id(message):
+        # type: (dict) -> object
+        request_id = message.get("id")
+        if isinstance(request_id, bool) or not isinstance(request_id, string_types + integer_types):
+            return None
+        return request_id
+
+    @staticmethod
+    def _validate_meta(params):
+        # type: (dict) -> dict
+        meta = params.get("_meta")
+        if not isinstance(meta, dict):
+            raise ValueError("params._meta must be an object.")
+        if not isinstance(meta.get(PROTOCOL_VERSION_KEY), string_types):
+            raise ValueError("{} is required.".format(PROTOCOL_VERSION_KEY))
+        if not isinstance(meta.get(CLIENT_CAPABILITIES_KEY), dict):
+            raise ValueError("{} is required.".format(CLIENT_CAPABILITIES_KEY))
+        client_info = meta.get(CLIENT_INFO_KEY)
+        if client_info is not None and (
+            not isinstance(client_info, dict)
+            or not isinstance(client_info.get("name"), string_types)
+            or not isinstance(client_info.get("version"), string_types)
+        ):
+            raise ValueError("{} must contain string name and version fields.".format(CLIENT_INFO_KEY))
+        return meta
+
+    def handle_message(self, message):
+        # type: (object) -> dict | None
+        if not isinstance(message, dict):
+            return _error_response(None, -32600, "Invalid Request")
+
+        request_id = self._request_id(message)
+        method = message.get("method")
+        if message.get("jsonrpc") != "2.0" or not isinstance(method, string_types):
+            return _error_response(request_id, -32600, "Invalid Request")
+        if "id" not in message:
+            if method == "notifications/initialized" and self._legacy_initialized:
+                self._legacy_ready = True
+            return None
+        if request_id is None:
+            return _error_response(None, -32600, "Invalid Request")
+
+        params = message.get("params", {})
+        if not isinstance(params, dict):
+            return _error_response(request_id, -32602, "Invalid params")
+        if method == "initialize" or self._legacy_initialized:
+            return self._handle_legacy_request(request_id, method, params)
+        return self._handle_modern_request(request_id, method, params)
+
+    def handle_line(self, line):
+        # type: (str | bytes) -> dict | None
+        if not isinstance(line, text_type):
+            try:
+                line = line.decode("utf-8")
+            except UnicodeDecodeError:
+                return _error_response(None, -32700, "Parse error")
+        try:
+            message = json.loads(line)
+        except (TypeError, ValueError):
+            return _error_response(None, -32700, "Parse error")
+        return self.handle_message(message)
+
+    def _record_cancellation(self, message):
+        # type: (object) -> bool
+        if not isinstance(message, dict) or message.get("method") != "notifications/cancelled":
+            return False
+        if message.get("jsonrpc") != "2.0" or "id" in message:
+            return True
+        params = message.get("params")
+        request_id = params.get("requestId") if isinstance(params, dict) else None
+        if isinstance(request_id, bool) or not isinstance(request_id, string_types + integer_types):
+            return True
+        with self._cancel_lock:
+            if request_id in self._pending:
+                self._cancelled.add(request_id)
+        return True
+
+    def _cancel_before_start(self, request_id):
+        # type: (object) -> bool
+        if request_id is None:
+            return False
+        with self._cancel_lock:
+            if request_id not in self._cancelled:
+                return False
+            self._cancelled.discard(request_id)
+            self._pending.discard(request_id)
+            return True
+
+    def _write_response(self, response, output_stream):
+        # type: (dict, object) -> None
+        request_id = response.get("id")
+        with self._cancel_lock:
+            if request_id in self._cancelled:
+                self._cancelled.discard(request_id)
+                self._pending.discard(request_id)
+                return
+            output_stream.write(json.dumps(response, ensure_ascii=True, separators=(",", ":")) + "\n")
+            output_stream.flush()
+            self._cancelled.discard(request_id)
+            self._pending.discard(request_id)
+
+    def _read_messages(self, input_stream, messages):
+        # type: (object, Queue) -> None
+        try:
+            for line in input_stream:
+                if not isinstance(line, text_type):
+                    try:
+                        line = line.decode("utf-8")
+                    except UnicodeDecodeError:
+                        messages.put((True, _error_response(None, -32700, "Parse error")))
+                        continue
+                try:
+                    message = json.loads(line)
+                except (TypeError, ValueError):
+                    messages.put((True, _error_response(None, -32700, "Parse error")))
+                    continue
+                if not self._record_cancellation(message):
+                    request_id = self._request_id(message) if isinstance(message, dict) and "id" in message else None
+                    if request_id is not None:
+                        with self._cancel_lock:
+                            self._pending.add(request_id)
+                    messages.put((False, message))
+        except (IOError, OSError, UnicodeError) as error:
+            self.logger.error("MCP input stream failed: %s", error)
+        finally:
+            messages.put(_END_OF_INPUT)
+
+    def serve(self, input_stream=None, output_stream=None):
+        # type: (object | None, object | None) -> None
+        input_stream = input_stream or getattr(sys.stdin, "buffer", sys.stdin)
+        output_stream = output_stream or sys.stdout
+        messages = Queue()
+        reader = threading.Thread(target=self._read_messages, args=(input_stream, messages), name="ddns-mcp-reader")
+        reader.daemon = True
+        reader.start()
+
+        while True:
+            item = messages.get()
+            if item is _END_OF_INPUT:
+                return
+            is_response, message = item
+            request_id = self._request_id(message) if isinstance(message, dict) and "id" in message else None
+            if not is_response and self._cancel_before_start(request_id):
+                continue
+            response = message if is_response else self.handle_message(message)
+            if response is None:
+                continue
+            self._write_response(response, output_stream)
+
+
+def serve(config_path=None, input_stream=None, output_stream=None, logger=None):
+    # type: (str | None, object | None, object | None, logging.Logger | None) -> None
+    """Run the DDNS MCP server until stdin reaches EOF."""
+    McpServer(config_path=config_path, logger=logger).serve(input_stream=input_stream, output_stream=output_stream)
+
+
+__all__ = ["LEGACY_PROTOCOL_VERSION", "McpServer", "PROTOCOL_VERSION", "TOOLS", "serve"]

--- a/ddns/mcp.py
+++ b/ddns/mcp.py
@@ -149,8 +149,8 @@ class McpServer(object):
             {"content": [{"type": "text", "text": text_type(error)}], "isError": True}, modern=modern
         )
 
-    def _call_tool(self, params, modern):
-        # type: (dict, bool) -> dict
+    def _call_tool(self, params, modern, request_id):
+        # type: (dict, bool, object) -> dict
         name = params.get("name")
         arguments = params.get("arguments", {})
         if not isinstance(name, string_types):
@@ -169,21 +169,21 @@ class McpServer(object):
             protocol_stdout = sys.stdout
             try:
                 sys.stdout = sys.stderr
-                status = service.sync(source="MCP")
+                status = service.sync(source="MCP", cancelled=lambda: self._is_cancelled(request_id))
             finally:
                 sys.stdout = protocol_stdout
             return self._tool_success(status, modern=modern)
         except DashboardError as error:
             return self._tool_error(error, modern=modern)
 
-    def _dispatch(self, method, params, modern):
-        # type: (str, dict, bool) -> dict | None
+    def _dispatch(self, method, params, modern, request_id):
+        # type: (str, dict, bool, object) -> dict | None
         if method == "server/discover":
             return self._discover() if modern else None
         if method == "tools/list":
             return self._list_tools(params, modern=modern)
         if method == "tools/call":
-            return self._call_tool(params, modern=modern)
+            return self._call_tool(params, modern=modern, request_id=request_id)
         if method == "ping" and not modern:
             return {}
         return None
@@ -216,7 +216,7 @@ class McpServer(object):
     def _dispatch_response(self, request_id, method, params, modern):
         # type: (object, str, dict, bool) -> dict
         try:
-            result = self._dispatch(method, params, modern=modern)
+            result = self._dispatch(method, params, modern=modern, request_id=request_id)
             if result is None:
                 return _error_response(request_id, -32601, "Method not found")
         except ValueError as error:
@@ -344,6 +344,11 @@ class McpServer(object):
             self._cancelled.discard(request_id)
             self._pending.discard(request_id)
             return True
+
+    def _is_cancelled(self, request_id):
+        # type: (object) -> bool
+        with self._cancel_lock:
+            return request_id in self._cancelled
 
     def _write_response(self, response, output_stream):
         # type: (dict, object) -> None

--- a/ddns/web/service.py
+++ b/ddns/web/service.py
@@ -1145,8 +1145,8 @@ class DashboardService(object):
                 "scheduler": self._scheduler_status(),
             }
 
-    def sync(self, source="同步"):
-        # type: (str) -> dict
+    def sync(self, source="同步", cancelled=None):
+        # type: (str, object | None) -> dict
         with self._lock:
             document = self.load_document()
             indexed_configs = [
@@ -1157,7 +1157,7 @@ class DashboardService(object):
             if not indexed_configs:
                 raise ConfigValidationError("Add at least one domain before running synchronization.")
 
-            from ..__main__ import run
+            from ..__main__ import UpdateCancelled, run
 
             failures = []
             successful_indexes = set()
@@ -1168,10 +1168,18 @@ class DashboardService(object):
             try:
                 for provider_index, config in indexed_configs:
                     try:
-                        if not run(config):
+                        if cancelled is not None and cancelled():
+                            raise UpdateCancelled("DDNS update cancelled.")
+                        result = run(config) if cancelled is None else run(config, cancelled=cancelled)
+                        if cancelled is not None and cancelled():
+                            raise UpdateCancelled("DDNS update cancelled.")
+                        if not result:
                             failures.append((provider_index, config.dns))
                         else:
                             successful_indexes.add(provider_index)
+                    except UpdateCancelled:
+                        self._record_activity("WARN", source, "同步已取消", config.dns)
+                        raise DashboardOperationError("Synchronization cancelled.")
                     except Exception:
                         self.logger.exception("Dashboard synchronization failed for %s", config.dns)
                         failures.append((provider_index, config.dns))

--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -335,6 +335,50 @@ ddns -c /etc/ddns/config.json --interval 5 --open
 
 如果检测到已启用的 `ddns task` 系统任务，Web 内置调度会停止执行并显示冲突。可以在控制台中显式接管，或先运行 `ddns task --disable`。两种调度方式不能同时运行。
 
+## MCP 服务
+
+`mcp` 子命令通过 stdio 启动一个仅使用 Python 标准库的本机 MCP 服务。它不会监听网络，也不会在协议参数或结果中返回服务商凭据。
+
+```bash
+ddns mcp -c /etc/ddns/config.json
+```
+
+配置路径优先级为 `-c/--config` > `DDNS_CONFIG` > 默认本地配置路径。MCP 模式只接受一份本地配置文件，不支持远程 URL 或多个 `-c`。stdout 专用于每行一条的 JSON-RPC 消息，运行日志只写入 stderr。
+
+### MCP 客户端配置
+
+在 GitHub Copilot CLI 中可以直接添加：
+
+```bash
+copilot mcp add ddns -- ddns mcp -c /etc/ddns/config.json
+```
+
+也可以在支持 MCP 的客户端配置中添加：
+
+```json
+{
+  "mcpServers": {
+    "ddns": {
+      "command": "ddns",
+      "args": ["mcp", "-c", "/etc/ddns/config.json"]
+    }
+  }
+}
+```
+
+Windows JSON 路径中的反斜杠需要写成 `\\`，也可以将 `command` 替换为 `ddns` 可执行文件的绝对路径。
+
+### 可用工具
+
+| 工具 | 参数 | 行为 |
+|------|------|------|
+| `get_ddns_status` | 无 | 读取本地配置、缓存地址、缓存记录、服务商摘要和最近同步时间，不实时查询 DNS 服务商 |
+| `update_dns_records` | 无 | 使用配置中的当前 IP 规则，对所有已配置记录执行一次完整同步，并返回同步后的状态 |
+
+`update_dns_records` 会修改外部 DNS 状态，客户端应在调用前保留人工确认。工具不接受域名、IP、服务商或凭据参数，避免模型绕过本地配置写入任意记录。
+
+当前实现支持 MCP `2026-07-28` 的无握手协议，并兼容 GitHub Copilot CLI 使用的 `2025-11-25` `initialize` 生命周期；不兼容更早协议，也不提供 HTTP、resources、prompts 或 subscriptions。状态来自 DDNS 本地缓存；关闭缓存后，独立的后续状态请求无法还原上一进程的同步历史，但更新调用本身仍会返回本次结果。
+
 ## Task Management (定时任务管理)
 
 DDNS 支持通过 `task` 子命令管理无 Web 场景的系统定时任务，可自动根据系统选择合适的调度器安装定时更新任务。

--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -377,6 +377,8 @@ Windows JSON 路径中的反斜杠需要写成 `\\`，也可以将 `command` 替
 
 `update_dns_records` 会修改外部 DNS 状态，客户端应在调用前保留人工确认。工具不接受域名、IP、服务商或凭据参数，避免模型绕过本地配置写入任意记录。
 
+客户端取消更新时，服务会在 IP 获取规则、域名记录及 DNS 服务商之间停止后续处理；已经发送给服务商的 API 请求无法撤销，可能仍会完成。
+
 当前实现支持 MCP `2026-07-28` 的无握手协议，并兼容 GitHub Copilot CLI 使用的 `2025-11-25` `initialize` 生命周期；不兼容更早协议，也不提供 HTTP、resources、prompts 或 subscriptions。状态来自 DDNS 本地缓存；关闭缓存后，独立的后续状态请求无法还原上一进程的同步历史，但更新调用本身仍会返回本次结果。
 
 ## Task Management (定时任务管理)

--- a/docs/en/config/cli.md
+++ b/docs/en/config/cli.md
@@ -303,6 +303,50 @@ ddns -c /etc/ddns/config.json --interval 5 --open
 
 When an enabled `ddns task` system task is detected, Web scheduling stops and reports a conflict. Explicitly take over in the console or run `ddns task --disable` first. The two scheduling modes cannot run together.
 
+## MCP server
+
+The `mcp` subcommand starts a local stdio MCP server implemented with the Python standard library only. It opens no network listener and never returns provider credentials in protocol arguments or results.
+
+```bash
+ddns mcp -c /etc/ddns/config.json
+```
+
+Configuration path precedence is `-c/--config` > `DDNS_CONFIG` > the conventional local config paths. MCP mode accepts exactly one local file; remote URLs and multiple `-c` values are rejected. stdout is reserved for one JSON-RPC message per line, while runtime logs go to stderr.
+
+### MCP client configuration
+
+Add the server directly to GitHub Copilot CLI:
+
+```bash
+copilot mcp add ddns -- ddns mcp -c /etc/ddns/config.json
+```
+
+Alternatively, add the following to an MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "ddns": {
+      "command": "ddns",
+      "args": ["mcp", "-c", "/etc/ddns/config.json"]
+    }
+  }
+}
+```
+
+Escape Windows path backslashes as `\\` in JSON, or replace `command` with the absolute path to the `ddns` executable.
+
+### Available tools
+
+| Tool | Arguments | Behavior |
+|------|-----------|----------|
+| `get_ddns_status` | None | Read local configuration, cached addresses and records, provider summaries, and the latest sync time; it does not query providers live |
+| `update_dns_records` | None | Resolve current addresses using the configuration, synchronize every configured record once, and return the resulting status |
+
+`update_dns_records` changes external DNS state, so clients should retain user confirmation before invoking it. The tool accepts no domain, address, provider, or credential arguments, preventing a model from bypassing the local configuration to write arbitrary records.
+
+This implementation supports the handshake-free MCP `2026-07-28` protocol and the `2025-11-25` `initialize` lifecycle used by GitHub Copilot CLI. It does not support earlier revisions or expose HTTP, resources, prompts, or subscriptions. Status comes from the local DDNS cache; when caching is disabled, a later independent status request cannot reconstruct sync history from a previous process, although the update call still returns its own result.
+
 ## Task Management
 
 For headless deployments, DDNS supports system scheduled tasks through the `task` subcommand, which automatically detects the system and selects the appropriate scheduler.

--- a/docs/en/config/cli.md
+++ b/docs/en/config/cli.md
@@ -345,6 +345,8 @@ Escape Windows path backslashes as `\\` in JSON, or replace `command` with the a
 
 `update_dns_records` changes external DNS state, so clients should retain user confirmation before invoking it. The tool accepts no domain, address, provider, or credential arguments, preventing a model from bypassing the local configuration to write arbitrary records.
 
+When a client cancels an update, the server stops before subsequent IP rules, domain records, or providers. A provider API request that has already been sent cannot be rolled back and may still complete.
+
 This implementation supports the handshake-free MCP `2026-07-28` protocol and the `2025-11-25` `initialize` lifecycle used by GitHub Copilot CLI. It does not support earlier revisions or expose HTTP, resources, prompts, or subscriptions. Status comes from the local DDNS cache; when caching is disabled, a later independent status request cannot reconstruct sync history from a previous process, although the update call still returns its own result.
 
 ## Task Management

--- a/tests/test_config_cli_mcp.py
+++ b/tests/test_config_cli_mcp.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Tests for the local MCP CLI command."""
+
+from __future__ import unicode_literals
+
+import sys
+
+from __init__ import patch, unittest
+
+from ddns.config.cli import _handle_mcp_command, load_config
+
+
+class TestMcpSubcommand(unittest.TestCase):
+    """Test MCP command parsing and local configuration restrictions."""
+
+    def setUp(self):
+        """Preserve command-line arguments between tests."""
+        self.original_argv = sys.argv[:]
+
+    def tearDown(self):
+        """Restore command-line arguments after each test."""
+        sys.argv = self.original_argv
+
+    def test_mcp_subcommand_defaults(self):
+        """Start MCP with the conventional local config resolution."""
+        sys.argv = ["ddns", "mcp"]
+        captured = [None]
+
+        with patch("ddns.config.cli._handle_mcp_command") as handler:
+            handler.side_effect = lambda args: captured.__setitem__(0, args)
+            with self.assertRaises(SystemExit) as context:
+                load_config("Test DDNS", "Test doc", "1.0.0", "2026-08-12")
+
+        self.assertEqual(context.exception.code, 0)
+        self.assertEqual(captured[0]["command"], "mcp")
+        self.assertIsNone(captured[0]["config"])
+
+    def test_mcp_subcommand_accepts_local_config(self):
+        """Pass one explicit local configuration to the MCP handler."""
+        sys.argv = ["ddns", "mcp", "-c", "config.json"]
+        captured = [None]
+
+        with patch("ddns.config.cli._handle_mcp_command") as handler:
+            handler.side_effect = lambda args: captured.__setitem__(0, args)
+            with self.assertRaises(SystemExit):
+                load_config("Test DDNS", "Test doc", "1.0.0", "2026-08-12")
+
+        self.assertEqual(captured[0]["config"], "config.json")
+
+    def test_mcp_subcommand_rejects_multiple_configs(self):
+        """Keep the MCP service bound to one deterministic local configuration."""
+        sys.argv = ["ddns", "mcp", "-c", "first.json", "-c", "second.json"]
+
+        with self.assertRaises(SystemExit) as context:
+            load_config("Test DDNS", "Test doc", "1.0.0", "2026-08-12")
+
+        self.assertEqual(context.exception.code, 2)
+
+    def test_mcp_subcommand_rejects_unknown_options(self):
+        """Fail rather than silently ignoring unsupported MCP options."""
+        sys.argv = ["ddns", "mcp", "--host", "127.0.0.1"]
+
+        with self.assertRaises(SystemExit) as context:
+            load_config("Test DDNS", "Test doc", "1.0.0", "2026-08-12")
+
+        self.assertEqual(context.exception.code, 2)
+
+    @patch("ddns.config.cli.basicConfig")
+    @patch("ddns.mcp.serve")
+    @patch("ddns.config.cli.load_env_config", return_value={})
+    def test_mcp_handler_starts_stdio_server(self, mock_load_env, mock_serve, mock_basic_config):
+        """Pass the selected path to the stdio server without loading DDNS CLI config."""
+        _handle_mcp_command({"config": "config.json"})
+
+        mock_basic_config.assert_called_once_with()
+        mock_load_env.assert_not_called()
+        mock_serve.assert_called_once_with(config_path="config.json")
+
+    @patch("ddns.config.cli.basicConfig")
+    @patch("ddns.mcp.serve")
+    @patch("ddns.config.cli.load_env_config", return_value={"config": "environment.json"})
+    def test_mcp_handler_uses_environment_config(self, mock_load_env, mock_serve, mock_basic_config):
+        """Use DDNS_CONFIG when no explicit path is supplied."""
+        _handle_mcp_command({})
+
+        mock_basic_config.assert_called_once_with()
+        mock_load_env.assert_called_once_with()
+        mock_serve.assert_called_once_with(config_path="environment.json")
+
+    @patch("ddns.mcp.serve")
+    def test_mcp_handler_rejects_remote_config(self, mock_serve):
+        """Do not let the local stdio server fetch remote credential documents."""
+        with self.assertRaises(SystemExit) as context:
+            _handle_mcp_command({"config": "https://example.com/config.json"})
+
+        self.assertEqual(context.exception.code, 2)
+        mock_serve.assert_not_called()
+
+    @patch("ddns.mcp.serve")
+    @patch("ddns.config.cli.load_env_config", return_value={"config": ["one.json", "two.json"]})
+    def test_mcp_handler_rejects_multiple_environment_configs(self, mock_load_env, mock_serve):
+        """Reject ambiguous DDNS_CONFIG lists."""
+        with self.assertRaises(SystemExit) as context:
+            _handle_mcp_command({})
+
+        self.assertEqual(context.exception.code, 2)
+        mock_load_env.assert_called_once_with()
+        mock_serve.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,9 @@
 Unit tests for the DDNS main run path.
 """
 
+import io
+import sys
+
 from __init__ import MagicMock, patch, unittest
 
 from ddns import __main__
@@ -26,6 +29,19 @@ class TestMain(unittest.TestCase):
         self.assertTrue(__main__.run(config))
         mock_cache_new.assert_called_once_with(True, config.md5(), __main__.logger, 86400)
         self.assertEqual(mock_update_ip.call_count, 2)
+
+    def test_mcp_mode_does_not_write_windows_leading_line(self):
+        """Keep stdout clean before the stdio protocol handler starts."""
+        output = io.StringIO()
+
+        with patch.object(sys, "argv", ["ddns", "mcp"]):
+            with patch.object(sys, "platform", "win32"):
+                with patch.object(sys, "stdout", output):
+                    with patch.object(__main__, "load_configs", side_effect=SystemExit(0)):
+                        with self.assertRaises(SystemExit):
+                            __main__.main()
+
+        self.assertEqual(output.getvalue(), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,7 @@ Unit tests for the DDNS main run path.
 
 import io
 import sys
+import threading
 
 from __init__ import MagicMock, patch, unittest
 
@@ -29,6 +30,39 @@ class TestMain(unittest.TestCase):
         self.assertTrue(__main__.run(config))
         mock_cache_new.assert_called_once_with(True, config.md5(), __main__.logger, 86400)
         self.assertEqual(mock_update_ip.call_count, 2)
+
+    @patch.object(__main__, "get_ip", return_value="192.0.2.1")
+    def test_update_ip_stops_before_next_domain_when_cancelled(self, mock_get_ip):
+        """Stop cooperative updates between configured DNS records."""
+        cancelled = threading.Event()
+        provider = MagicMock()
+        provider.set_record.side_effect = lambda *args, **kwargs: cancelled.set() or True
+        config = Config(cli_config={"dns": "debug"})
+
+        with self.assertRaises(__main__.UpdateCancelled):
+            __main__.update_ip(
+                provider,
+                None,
+                ["public"],
+                ["first.example.com", "second.example.com"],
+                "A",
+                config,
+                cancelled=cancelled.is_set,
+            )
+
+        provider.set_record.assert_called_once()
+        mock_get_ip.assert_called_once()
+
+    @patch.object(__main__, "_get_ip_from_rule")
+    def test_get_ip_stops_before_next_rule_when_cancelled(self, mock_get_rule):
+        """Stop cooperative address discovery between configured rules."""
+        cancelled = threading.Event()
+        mock_get_rule.side_effect = lambda *args: cancelled.set()
+
+        with self.assertRaises(__main__.UpdateCancelled):
+            __main__.get_ip("4", ["first", "second"], cancelled=cancelled.is_set)
+
+        mock_get_rule.assert_called_once_with("4", "first")
 
     def test_mcp_mode_does_not_write_windows_leading_line(self):
         """Keep stdout clean before the stdio protocol handler starts."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -19,6 +19,31 @@ from ddns.mcp import (
 )
 from ddns.web.service import DashboardOperationError
 
+try:
+    text_type = unicode  # type: ignore[name-defined]
+except NameError:
+    text_type = str
+
+
+class TextCapture(object):
+    """Capture both byte and Unicode writes on Python 2 and 3."""
+
+    def __init__(self):
+        self._stream = io.StringIO()
+
+    def write(self, value):
+        """Normalize byte writes before forwarding them to the text stream."""
+        if not isinstance(value, text_type):
+            value = value.decode("utf-8")
+        return self._stream.write(value)
+
+    def flush(self):
+        """Match the file API used by print and logging."""
+
+    def getvalue(self):
+        """Return all captured text."""
+        return self._stream.getvalue()
+
 
 class TestMcpServer(unittest.TestCase):
     """Test modern MCP request validation and DDNS tool dispatch."""
@@ -102,21 +127,23 @@ class TestMcpServer(unittest.TestCase):
         response = server.handle_message(self._request("tools/call", {"name": "update_dns_records", "arguments": {}}))
 
         self.assertFalse(response["result"]["isError"])
-        service.sync.assert_called_once_with(source="MCP")
+        self.assertEqual(service.sync.call_args[1]["source"], "MCP")
+        self.assertTrue(callable(service.sync.call_args[1]["cancelled"]))
+        self.assertFalse(service.sync.call_args[1]["cancelled"]())
 
     def test_update_tool_redirects_provider_stdout_to_stderr(self):
         """Prevent provider print calls from corrupting the MCP protocol stream."""
         service = MagicMock()
 
-        def noisy_sync(source):
+        def noisy_sync(source, cancelled=None):
             """Simulate the existing debug provider's print-based output."""
             print("provider output")
             return self._dashboard()
 
         service.sync.side_effect = noisy_sync
         server = McpServer(service_factory=MagicMock(return_value=service))
-        protocol_stdout = io.StringIO()
-        protocol_stderr = io.StringIO()
+        protocol_stdout = TextCapture()
+        protocol_stderr = TextCapture()
 
         with patch("ddns.mcp.sys.stdout", protocol_stdout):
             with patch("ddns.mcp.sys.stderr", protocol_stderr):
@@ -323,11 +350,12 @@ class TestMcpServer(unittest.TestCase):
                 cancellation_seen.set()
             return recorded
 
-        def blocking_sync(source):
-            """Wait until the reader consumes the cancellation."""
+        def blocking_sync(source, cancelled=None):
+            """Wait until the reader consumes and exposes the cancellation."""
             started.set()
             self.assertTrue(cancellation_seen.wait(1))
-            return self._dashboard()
+            self.assertTrue(cancelled())
+            raise DashboardOperationError("Synchronization cancelled.")
 
         def input_lines():
             """Send cancellation only after synchronization has started."""
@@ -341,7 +369,8 @@ class TestMcpServer(unittest.TestCase):
 
         server.serve(input_stream=input_lines(), output_stream=output_stream)
 
-        service.sync.assert_called_once_with(source="MCP")
+        self.assertEqual(service.sync.call_args[1]["source"], "MCP")
+        self.assertTrue(callable(service.sync.call_args[1]["cancelled"]))
         self.assertEqual(output_stream.getvalue(), "")
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+"""Tests for the dependency-free MCP stdio server."""
+
+from __future__ import unicode_literals
+
+import io
+import json
+import threading
+
+from __init__ import MagicMock, patch, unittest
+
+from ddns.mcp import (
+    CLIENT_CAPABILITIES_KEY,
+    LEGACY_PROTOCOL_VERSION,
+    PROTOCOL_VERSION,
+    PROTOCOL_VERSION_KEY,
+    SERVER_INFO_KEY,
+    McpServer,
+)
+from ddns.web.service import DashboardOperationError
+
+
+class TestMcpServer(unittest.TestCase):
+    """Test modern MCP request validation and DDNS tool dispatch."""
+
+    def _request(self, method, params=None, request_id=1, version=PROTOCOL_VERSION):
+        """Build one valid modern MCP request."""
+        params = dict(params or {})
+        params["_meta"] = {
+            PROTOCOL_VERSION_KEY: version,
+            CLIENT_CAPABILITIES_KEY: {},
+            "io.modelcontextprotocol/clientInfo": {"name": "test-client", "version": "1.0"},
+        }
+        return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+
+    @staticmethod
+    def _dashboard():
+        """Return representative status with unrelated sensitive fields."""
+        return {
+            "state": "synced",
+            "message": "ready",
+            "config_path": "config.json",
+            "last_sync": 123.0,
+            "addresses": [{"family": "IPv4", "value": "192.0.2.1"}],
+            "providers": [{"id": "debug", "records": 1, "status": "synced"}],
+            "records": [{"domain": "example.com", "type": "A", "value": "192.0.2.1"}],
+            "activities": [{"level": "INFO", "message": "done"}],
+            "scheduler": {"token": "scheduler-secret"},
+            "token": "provider-secret",
+        }
+
+    def test_discover_declares_modern_tool_capability(self):
+        """Advertise supported protocol versions and the tool capability."""
+        response = McpServer().handle_message(self._request("server/discover"))
+
+        result = response["result"]
+        self.assertEqual(result["resultType"], "complete")
+        self.assertEqual(result["supportedVersions"], [PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION])
+        self.assertEqual(result["capabilities"], {"tools": {}})
+        self.assertEqual(result["cacheScope"], "public")
+        self.assertIn(SERVER_INFO_KEY, result["_meta"])
+
+    def test_tools_list_is_deterministic_and_describes_side_effects(self):
+        """List status before update and expose accurate safety annotations."""
+        response = McpServer().handle_message(self._request("tools/list"))
+
+        result = response["result"]
+        tools = result["tools"]
+        self.assertEqual([tool["name"] for tool in tools], ["get_ddns_status", "update_dns_records"])
+        self.assertTrue(tools[0]["annotations"]["readOnlyHint"])
+        self.assertFalse(tools[1]["annotations"]["readOnlyHint"])
+        self.assertTrue(tools[1]["annotations"]["destructiveHint"])
+        self.assertEqual(tools[0]["inputSchema"], {"type": "object", "additionalProperties": False})
+        self.assertEqual(result["ttlMs"], 3600000)
+
+    def test_status_tool_returns_only_whitelisted_state(self):
+        """Return local state without exposing configuration credentials."""
+        service = MagicMock()
+        service.dashboard.return_value = self._dashboard()
+        factory = MagicMock(return_value=service)
+        server = McpServer(config_path="config.json", service_factory=factory)
+
+        response = server.handle_message(self._request("tools/call", {"name": "get_ddns_status", "arguments": {}}))
+
+        result = response["result"]
+        self.assertFalse(result["isError"])
+        self.assertEqual(result["structuredContent"]["state"], "synced")
+        self.assertNotIn("token", result["structuredContent"])
+        self.assertNotIn("scheduler", result["structuredContent"])
+        self.assertNotIn("config_path", result["structuredContent"])
+        self.assertNotIn("activities", result["structuredContent"])
+        self.assertNotIn("provider-secret", result["content"][0]["text"])
+        factory.assert_called_once_with(config_path="config.json", logger=server.logger)
+        service.dashboard.assert_called_once_with()
+
+    def test_update_tool_runs_complete_config_sync(self):
+        """Invoke the existing full synchronization without accepting record arguments."""
+        service = MagicMock()
+        service.sync.return_value = self._dashboard()
+        server = McpServer(service_factory=MagicMock(return_value=service))
+
+        response = server.handle_message(self._request("tools/call", {"name": "update_dns_records", "arguments": {}}))
+
+        self.assertFalse(response["result"]["isError"])
+        service.sync.assert_called_once_with(source="MCP")
+
+    def test_update_tool_redirects_provider_stdout_to_stderr(self):
+        """Prevent provider print calls from corrupting the MCP protocol stream."""
+        service = MagicMock()
+
+        def noisy_sync(source):
+            """Simulate the existing debug provider's print-based output."""
+            print("provider output")
+            return self._dashboard()
+
+        service.sync.side_effect = noisy_sync
+        server = McpServer(service_factory=MagicMock(return_value=service))
+        protocol_stdout = io.StringIO()
+        protocol_stderr = io.StringIO()
+
+        with patch("ddns.mcp.sys.stdout", protocol_stdout):
+            with patch("ddns.mcp.sys.stderr", protocol_stderr):
+                response = server.handle_message(
+                    self._request("tools/call", {"name": "update_dns_records", "arguments": {}})
+                )
+
+        self.assertFalse(response["result"]["isError"])
+        self.assertEqual(protocol_stdout.getvalue(), "")
+        self.assertEqual(protocol_stderr.getvalue().strip(), "provider output")
+
+    def test_tool_rejects_arbitrary_arguments(self):
+        """Prevent the model from supplying arbitrary domains, addresses, or credentials."""
+        factory = MagicMock()
+        server = McpServer(service_factory=factory)
+
+        response = server.handle_message(
+            self._request("tools/call", {"name": "update_dns_records", "arguments": {"domain": "example.com"}})
+        )
+
+        self.assertEqual(response["error"]["code"], -32602)
+        factory.assert_not_called()
+
+    def test_dashboard_error_is_a_tool_execution_error(self):
+        """Return actionable DDNS failures to the model as tool results."""
+        service = MagicMock()
+        service.sync.side_effect = DashboardOperationError("Synchronization failed for: debug.")
+        server = McpServer(service_factory=MagicMock(return_value=service))
+
+        response = server.handle_message(self._request("tools/call", {"name": "update_dns_records", "arguments": {}}))
+
+        self.assertTrue(response["result"]["isError"])
+        self.assertIn("Synchronization failed", response["result"]["content"][0]["text"])
+
+    def test_unexpected_tool_error_is_sanitized(self):
+        """Keep unexpected exception details out of the protocol response."""
+        service = MagicMock()
+        service.dashboard.side_effect = RuntimeError("provider-secret")
+        logger = MagicMock()
+        server = McpServer(logger=logger, service_factory=MagicMock(return_value=service))
+
+        response = server.handle_message(self._request("tools/call", {"name": "get_ddns_status", "arguments": {}}))
+
+        self.assertEqual(response["error"], {"code": -32603, "message": "Internal error"})
+        self.assertNotIn("provider-secret", json.dumps(response))
+        logger.getChild.return_value.exception.assert_called_once_with("Unhandled MCP request failure")
+
+    def test_missing_metadata_is_invalid_params(self):
+        """Require modern per-request metadata instead of an initialize handshake."""
+        request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+
+        response = McpServer().handle_message(request)
+
+        self.assertEqual(response["error"]["code"], -32602)
+
+    def test_invalid_optional_client_info_is_rejected(self):
+        """Validate client identity metadata when a client supplies it."""
+        request = self._request("tools/list")
+        request["params"]["_meta"]["io.modelcontextprotocol/clientInfo"] = {"name": 1, "version": "1.0"}
+
+        response = McpServer().handle_message(request)
+
+        self.assertEqual(response["error"]["code"], -32602)
+
+    def test_unsupported_version_lists_supported_version(self):
+        """Return the protocol-defined version mismatch error."""
+        response = McpServer().handle_message(self._request("server/discover", version="2025-11-25"))
+
+        self.assertEqual(response["error"]["code"], -32022)
+        self.assertEqual(response["error"]["data"]["supported"], [PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION])
+        self.assertEqual(response["error"]["data"]["requested"], "2025-11-25")
+
+    def test_legacy_copilot_lifecycle_lists_and_calls_tools(self):
+        """Support the MCP 2025-11-25 lifecycle used by GitHub Copilot CLI."""
+        service = MagicMock()
+        service.dashboard.return_value = self._dashboard()
+        server = McpServer(service_factory=MagicMock(return_value=service))
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": LEGACY_PROTOCOL_VERSION,
+                "capabilities": {"sampling": {}},
+                "clientInfo": {"name": "github-copilot-developer", "version": "1.0.79"},
+            },
+        }
+
+        initialize_response = server.handle_message(initialize)
+        initialized_response = server.handle_message({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        list_response = server.handle_message(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {"_meta": {"progressToken": 0}}}
+        )
+        call_response = server.handle_message(
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "get_ddns_status", "arguments": {}}}
+        )
+
+        self.assertEqual(initialize_response["result"]["protocolVersion"], LEGACY_PROTOCOL_VERSION)
+        self.assertNotIn("resultType", initialize_response["result"])
+        self.assertIsNone(initialized_response)
+        self.assertEqual(
+            [tool["name"] for tool in list_response["result"]["tools"]], ["get_ddns_status", "update_dns_records"]
+        )
+        self.assertNotIn("resultType", list_response["result"])
+        self.assertNotIn("ttlMs", list_response["result"])
+        self.assertFalse(call_response["result"]["isError"])
+        self.assertNotIn("resultType", call_response["result"])
+        service.dashboard.assert_called_once_with()
+
+    def test_legacy_ping_works_before_initialized_notification(self):
+        """Allow the legacy lifecycle health check during initialization."""
+        server = McpServer()
+        server.handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": LEGACY_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "client", "version": "1.0"},
+                },
+            }
+        )
+
+        response = server.handle_message({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+
+        self.assertEqual(response["result"], {})
+
+    def test_missing_meta_discover_allows_legacy_fallback(self):
+        """Return Method not found for Copilot's legacy-era discovery probe."""
+        response = McpServer().handle_message({"jsonrpc": "2.0", "id": 1, "method": "server/discover", "params": {}})
+
+        self.assertEqual(response["error"]["code"], -32601)
+
+    def test_unknown_method_and_tool_are_protocol_errors(self):
+        """Use JSON-RPC errors for unsupported protocol operations."""
+        method_response = McpServer().handle_message(self._request("resources/list"))
+        tool_response = McpServer().handle_message(self._request("tools/call", {"name": "missing", "arguments": {}}))
+
+        self.assertEqual(method_response["error"]["code"], -32601)
+        self.assertEqual(tool_response["error"]["code"], -32602)
+
+    def test_invalid_json_and_request_id_are_rejected(self):
+        """Return parse and invalid-request errors with a null response ID."""
+        parse_response = McpServer().handle_line("{")
+        id_response = McpServer().handle_message(self._request("tools/list", request_id=True))
+
+        self.assertEqual(parse_response["error"]["code"], -32700)
+        self.assertIsNone(parse_response["id"])
+        self.assertEqual(id_response["error"]["code"], -32600)
+        self.assertIsNone(id_response["id"])
+
+    def test_utf8_bytes_are_decoded_explicitly(self):
+        """Accept UTF-8 request bytes independently of the process locale."""
+        request = self._request("server/discover")
+        request["params"]["_meta"]["io.modelcontextprotocol/clientInfo"]["name"] = "测试客户端"
+        line = json.dumps(request, ensure_ascii=False).encode("utf-8")
+
+        response = McpServer().handle_line(line)
+
+        self.assertEqual(response["result"]["supportedVersions"], [PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION])
+
+    def test_notifications_do_not_receive_responses(self):
+        """Honor JSON-RPC notification semantics."""
+        notification = {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {"requestId": 1}}
+
+        self.assertIsNone(McpServer().handle_message(notification))
+
+    def test_stdio_writes_one_json_response_per_line(self):
+        """Keep stdout limited to newline-delimited JSON-RPC responses."""
+        notification = {"jsonrpc": "2.0", "method": "notifications/cancelled"}
+        malformed_cancellation = {"jsonrpc": "1.0", "id": 4, "method": "notifications/cancelled"}
+        input_stream = io.StringIO(
+            json.dumps(notification)
+            + "\n"
+            + json.dumps(malformed_cancellation)
+            + "\n"
+            + json.dumps(self._request("server/discover"))
+            + "\n"
+        )
+        output_stream = io.StringIO()
+
+        McpServer().serve(input_stream=input_stream, output_stream=output_stream)
+
+        lines = output_stream.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            json.loads(lines[0])["result"]["supportedVersions"], [PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION]
+        )
+
+    def test_in_flight_cancellation_suppresses_tool_response(self):
+        """Observe cancellation while a blocking synchronization is running."""
+        started = threading.Event()
+        cancellation_seen = threading.Event()
+        service = MagicMock()
+        server = McpServer(service_factory=MagicMock(return_value=service))
+        original_record_cancellation = server._record_cancellation
+
+        def record_cancellation(message):
+            """Signal after the reader records a cancellation notification."""
+            recorded = original_record_cancellation(message)
+            if isinstance(message, dict) and message.get("method") == "notifications/cancelled":
+                cancellation_seen.set()
+            return recorded
+
+        def blocking_sync(source):
+            """Wait until the reader consumes the cancellation."""
+            started.set()
+            self.assertTrue(cancellation_seen.wait(1))
+            return self._dashboard()
+
+        def input_lines():
+            """Send cancellation only after synchronization has started."""
+            yield json.dumps(self._request("tools/call", {"name": "update_dns_records", "arguments": {}}, request_id=9))
+            self.assertTrue(started.wait(1))
+            yield json.dumps({"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {"requestId": 9}})
+
+        server._record_cancellation = record_cancellation
+        service.sync.side_effect = blocking_sync
+        output_stream = io.StringIO()
+
+        server.serve(input_stream=input_lines(), output_stream=output_stream)
+
+        service.sync.assert_called_once_with(source="MCP")
+        self.assertEqual(output_stream.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -731,6 +731,30 @@ class TestDashboardService(unittest.TestCase):
         self.assertEqual(mock_run.call_count, 2)
         self.assertEqual([provider["status"] for provider in dashboard["providers"]], ["error", "synced"])
 
+    @patch("ddns.__main__.run")
+    def test_sync_stops_before_next_provider_when_cancelled(self, mock_run):
+        """Stop cooperative synchronization between configured providers."""
+        config = _valid_config()
+        second = copy.deepcopy(config["providers"][0])
+        second["ipv4"] = ["second.example.com"]
+        config["providers"].append(second)
+        self.service.save(config)
+        cancel_event = threading.Event()
+
+        def cancel_after_first(_config, cancelled=None):
+            """Cancel after the first provider returns."""
+            self.assertTrue(callable(cancelled))
+            cancel_event.set()
+            return True
+
+        mock_run.side_effect = cancel_after_first
+
+        with self.assertRaises(DashboardOperationError) as context:
+            self.service.sync(source="MCP", cancelled=cancel_event.is_set)
+
+        self.assertIn("cancelled", str(context.exception).lower())
+        mock_run.assert_called_once()
+
     def test_scheduler_action_uses_selected_interval(self):
         """Update the interval for the current web process."""
         result = self.service.configure_scheduler("configure", interval=12)


### PR DESCRIPTION
## Summary

- add a standard-library-only stdio MCP server via `ddns mcp -c config.json`
- expose `get_ddns_status` and `update_dns_records` without accepting arbitrary credentials, domains, or addresses
- support MCP `2026-07-28` plus the `2025-11-25` lifecycle used by GitHub Copilot CLI
- keep protocol stdout isolated, handle cancellation and UTF-8 input, and document setup in Chinese and English

## Testing

- `python -m unittest discover tests` (1058 tests passed, 22 skipped)
- focused MCP, CLI, and main tests after rebase (30 passed)
- `ruff check .`
- GitHub Copilot CLI 1.0.79 end-to-end MCP connection and both tool calls