### PR TITLE
fix(http): bound external requests in CI tests

### DIFF
--- a/ddns/config/file.py
+++ b/ddns/config/file.py
@@ -71,8 +71,8 @@ def _flatten_single_config(config, exclude_keys=None, preserve_keys=None):
     return flat_config
 
 
-def load_config(config_path, proxy=None, ssl="auto", raw=False):
-    # type: (str, list[str] | None, bool | str, bool) -> dict|list[dict]
+def load_config(config_path, proxy=None, ssl="auto", raw=False, timeout=None):
+    # type: (str, list[str] | None, bool | str, bool, float | None) -> dict|list[dict]
     """
     加载配置文件并返回配置字典或配置字典数组。
     支持本地文件和远程HTTP(S) URL。
@@ -84,6 +84,7 @@ def load_config(config_path, proxy=None, ssl="auto", raw=False):
         proxy (list[str] | None): 代理列表，仅用于HTTP或HTTPS请求
         ssl (bool | str): SSL验证配置，仅用于HTTPS请求
         raw (bool): 返回解析后的原始结构，不展开多服务商配置
+        timeout (float | None): 远程配置单次请求的超时秒数
 
     Returns:
         dict|list[dict]: 配置字典或配置字典数组
@@ -95,7 +96,10 @@ def load_config(config_path, proxy=None, ssl="auto", raw=False):
         # 检查是否为远程URL
         if "://" in config_path:
             # 使用HTTP请求获取远程配置
-            response = request("GET", config_path, proxies=proxy, verify=ssl, retries=3)
+            request_options = {"proxies": proxy, "verify": ssl, "retries": 3}
+            if timeout is not None:
+                request_options["timeout"] = timeout
+            response = request("GET", config_path, **request_options)
             if (response.status not in (200, None)) or not response.body:
                 stderr.write("Failed to load {}: HTTP {} {}\n".format(config_path, response.status, response.reason))
                 stderr.write("Response body: %s\n" % response.body)

--- a/ddns/provider/_base.py
+++ b/ddns/provider/_base.py
@@ -171,8 +171,8 @@ class SimpleProvider(object):
         if not self.endpoint:
             raise ValueError("API endpoint must be defined in {}".format(self.__class__.__name__))
 
-    def _http(self, method, url, params=None, body=None, queries=None, headers=None):  # noqa: C901
-        # type: (str, str, dict[str,Any]|str|None, dict[str,Any]|str|None, dict[str,Any]|None, dict|None) -> Any
+    def _http(self, method, url, params=None, body=None, queries=None, headers=None, timeout=None, retries=2):  # noqa: C901
+        # type: (str, str, dict[str,Any]|str|None, dict[str,Any]|str|None, dict[str,Any]|None, dict|None, float|None, int) -> Any # noqa: E501
         """
         发送 HTTP/HTTPS 请求，自动根据 API/url 选择协议。
 
@@ -183,6 +183,8 @@ class SimpleProvider(object):
             body (dict[str, Any] | str | None): 请求体内容
             queries (dict[str, Any] | None): 查询参数，自动处理为 URL 查询字符串
             headers (dict): 头部，可选
+            timeout (float | None): 单次 HTTP 请求超时秒数
+            retries (int): HTTP 请求重试次数
 
         Returns:
             Any: 解析后的响应内容
@@ -233,7 +235,16 @@ class SimpleProvider(object):
             self.logger.debug("headers:\n%s", {k: self._mask_sensitive_data(v) for k, v in headers.items()})
 
         # 直接传递代理列表给request函数
-        response = request(method, url, body_data, headers=headers, proxies=self._proxy, verify=self._ssl, retries=2)
+        response = request(
+            method,
+            url,
+            body_data,
+            headers=headers,
+            proxies=self._proxy,
+            verify=self._ssl,
+            retries=retries,
+            timeout=timeout,
+        )
         # 处理响应
         status_code = response.status
         if not (200 <= status_code < 300):

--- a/ddns/util/http.py
+++ b/ddns/util/http.py
@@ -65,8 +65,8 @@ def _proxy_handler(proxy):
     return ProxyHandler({"http": proxy, "https": proxy})
 
 
-def request(method, url, data=None, headers=None, proxies=None, verify=True, auth=None, retries=1):
-    # type: (str, str, str | bytes | None, dict[str, str] | None, list[str] | None, bool | str, BaseHandler | None, int) -> HttpResponse # noqa: E501
+def request(method, url, data=None, headers=None, proxies=None, verify=True, auth=None, retries=1, timeout=None):
+    # type: (str, str, str | bytes | None, dict[str, str] | None, list[str] | None, bool | str, BaseHandler | None, int, float | None) -> HttpResponse # noqa: E501
     """
     发送HTTP/HTTPS请求，支持自动重试和类似requests.request的参数接口
 
@@ -86,6 +86,7 @@ def request(method, url, data=None, headers=None, proxies=None, verify=True, aut
                             - str: 自定义CA证书文件路径
         auth (BaseHandler | None): 自定义认证处理器
         retries (int): 最大重试次数，默认1次
+        timeout (float | None): 单次请求超时秒数；默认 GET 60 秒，其他请求 120 秒
 
     Returns:
         HttpResponse: 响应对象
@@ -114,12 +115,13 @@ def request(method, url, data=None, headers=None, proxies=None, verify=True, aut
 
     handlers = [NoHTTPErrorHandler(), AutoSSLHandler(verify), RetryHandler(retries)]
     handlers += [auth] if auth else []
+    request_timeout = timeout if timeout is not None else (60 if method.upper() == "GET" else 120)
 
     def run(proxy_handler):
         req = Request(url, data=data, headers=headers)
         req.get_method = lambda: method.upper()  # python 2 兼容
         h = handlers + ([proxy_handler] if proxy_handler else [])
-        return build_opener(*h).open(req, timeout=60 if method == "GET" else 120)  # 创建处理器链
+        return build_opener(*h).open(req, timeout=request_timeout)  # 创建处理器链
 
     if not proxies:
         response = run(None)  # 默认

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,8 @@ import sys
 import os
 import unittest
 
+TEST_HTTP_TIMEOUT = 5
+
 try:
     from unittest import mock  # type: ignore
     from unittest.mock import patch, MagicMock, call
@@ -14,7 +16,7 @@ except ImportError:  # Python 2
     from mock import patch, MagicMock, call  # type: ignore
     import mock  # type: ignore
 
-__all__ = ["patch", "MagicMock", "unittest", "call", "mock"]
+__all__ = ["patch", "MagicMock", "unittest", "call", "mock", "TEST_HTTP_TIMEOUT"]
 
 # 添加当前目录到 Python 路径，这样就可以直接导入 test_base
 current_dir = os.path.dirname(__file__)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -4,7 +4,9 @@ Base test utilities and common imports for all provider tests
 @author: NewFuture
 """
 
-from __init__ import unittest, patch, MagicMock  # noqa: F401 # Ensure the package is initialized
+from functools import partial
+
+from __init__ import TEST_HTTP_TIMEOUT, unittest, patch, MagicMock  # noqa: F401 # Ensure package initialization
 
 
 class BaseProviderTestCase(unittest.TestCase):
@@ -25,6 +27,11 @@ class BaseProviderTestCase(unittest.TestCase):
         provider.logger = MagicMock()
         return provider.logger
 
+    def configure_test_http(self, provider, timeout=TEST_HTTP_TIMEOUT):
+        """Bound real HTTP calls in integration tests."""
+        provider._http = partial(provider._http, timeout=timeout, retries=0)
+        return provider
+
 
 # Export commonly used imports for convenience
-__all__ = ["BaseProviderTestCase", "unittest", "patch", "MagicMock"]
+__all__ = ["BaseProviderTestCase", "unittest", "patch", "MagicMock", "TEST_HTTP_TIMEOUT"]

--- a/tests/test_config_file_remote.py
+++ b/tests/test_config_file_remote.py
@@ -6,7 +6,7 @@ Unit tests for remote configuration loading in ddns.config.file module
 """
 
 from __future__ import unicode_literals
-from __init__ import unittest, patch
+from __init__ import TEST_HTTP_TIMEOUT, unittest, patch
 import tempfile
 import shutil
 import os
@@ -83,6 +83,20 @@ class TestRemoteConfigFile(unittest.TestCase):
 
         self.assertEqual(result, config_data)
         mock_http.assert_called_once_with("GET", config_url, proxies=None, verify=True, retries=3)
+
+    @patch("ddns.config.file.request")
+    def test_load_config_remote_with_timeout(self, mock_http):
+        """Forward an explicit timeout for remote configurations."""
+        config_data = {"dns": "debug"}
+        mock_http.return_value = HttpResponse(200, "OK", {}, json.dumps(config_data))
+        config_url = "https://secure.example.com/config.json"
+
+        result = load_config(config_url, timeout=TEST_HTTP_TIMEOUT)
+
+        self.assertEqual(result, config_data)
+        mock_http.assert_called_once_with(
+            "GET", config_url, proxies=None, verify="auto", retries=3, timeout=TEST_HTTP_TIMEOUT
+        )
 
     @patch("ddns.config.file.request")
     def test_load_config_remote_with_proxy(self, mock_http):
@@ -353,7 +367,7 @@ class TestRemoteConfigFile(unittest.TestCase):
         # This is a real integration test - it should succeed if the URL is accessible
         # If the URL is not accessible due to network issues, the test will be skipped
         try:
-            result = load_config(config_url)
+            result = load_config(config_url, timeout=TEST_HTTP_TIMEOUT)
 
             # Handle both single config (dict) and multi-provider config (list)
             if isinstance(result, list):

--- a/tests/test_provider_callback.py
+++ b/tests/test_provider_callback.py
@@ -351,6 +351,7 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
         for endpoint_id in test_endpoints:
             try:
                 provider = CallbackProvider(endpoint_id, "", ssl="auto")
+                self.configure_test_http(provider)
                 mock_logger = self._setup_provider_with_mock_logger(provider)
 
                 self._random_delay()  # Add random delay before real request
@@ -400,6 +401,7 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
         for endpoint_id in test_endpoints:
             try:
                 provider = CallbackProvider(endpoint_id, token)
+                self.configure_test_http(provider)
                 # Setup provider with mock logger
                 mock_logger = self._setup_provider_with_mock_logger(provider)
 
@@ -444,6 +446,7 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
         # Use an invalid URL to test error handling
         id = "http://postman-echo.com/status/400"  # This returns HTTP 400
         provider = CallbackProvider(id, "")
+        self.configure_test_http(provider)
 
         self._random_delay()  # Add random delay before real request
         result = provider.set_record("test.example.com", "203.0.113.5")

--- a/tests/test_provider_dnspod.py
+++ b/tests/test_provider_dnspod.py
@@ -540,6 +540,7 @@ class TestDnspodProviderRealRequest(BaseProviderTestCase):
         """Test authentication failure with real API request"""
         # 使用无效的认证信息创建 provider
         invalid_provider = DnspodProvider("invalid_id", "invalid_token")
+        self.configure_test_http(invalid_provider)
 
         # 尝试查询域名信息，应该抛出认证失败异常
         with self.assertRaises(RuntimeError) as cm:

--- a/tests/test_provider_edgeone.py
+++ b/tests/test_provider_edgeone.py
@@ -477,6 +477,7 @@ class TestEdgeOneProviderRealRequest(BaseProviderTestCase):
         """Test authentication failure with real API request"""
         # 使用无效的认证信息创建 provider
         invalid_provider = EdgeOneProvider("invalid_id", "invalid_token")
+        self.configure_test_http(invalid_provider)
 
         # Mock logger to capture error logs
         invalid_provider.logger = MagicMock()

--- a/tests/test_provider_edgeone_dns.py
+++ b/tests/test_provider_edgeone_dns.py
@@ -426,6 +426,7 @@ class TestEdgeOneDnsProviderRealRequest(BaseProviderTestCase):
         """Test authentication failure with real API request"""
         # 使用无效的认证信息创建 provider
         invalid_provider = EdgeOneDnsProvider("invalid_id", "invalid_token")
+        self.configure_test_http(invalid_provider)
 
         # Mock logger to capture error logs
         invalid_provider.logger = MagicMock()

--- a/tests/test_provider_proxy_list.py
+++ b/tests/test_provider_proxy_list.py
@@ -115,6 +115,18 @@ class TestProviderProxyList(BaseProviderTestCase):
         self.assertEqual(call_args[1]["proxies"], [])
 
     @patch("ddns.provider._base.request")
+    def test_provider_http_forwards_timeout_and_retries(self, mock_request):
+        """Allow callers to bound individual provider HTTP requests."""
+        mock_request.return_value = HttpResponse(200, "OK", {}, '{"status": "success"}')
+        provider = TestSimpleProvider(self.id, self.token)
+
+        provider._http("GET", "/test", timeout=5, retries=0)
+
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[1]["timeout"], 5)
+        self.assertEqual(call_args[1]["retries"], 0)
+
+    @patch("ddns.provider._base.request")
     def test_provider_http_request_failure_handling(self, mock_request):
         """测试Provider处理请求失败的情况"""
         # 模拟请求失败

--- a/tests/test_provider_tencentcloud.py
+++ b/tests/test_provider_tencentcloud.py
@@ -535,6 +535,7 @@ class TestTencentCloudProviderRealRequest(BaseProviderTestCase):
         """Test authentication failure with real API request"""
         # 使用无效的认证信息创建 provider
         invalid_provider = TencentCloudProvider("invalid_id", "invalid_token")
+        self.configure_test_http(invalid_provider)
 
         # Mock logger to capture error logs
         invalid_provider.logger = MagicMock()

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -6,7 +6,7 @@ Test ddns.util.http module
 """
 
 from __future__ import unicode_literals
-from __init__ import unittest, sys
+from __init__ import patch, unittest, sys
 import json
 import socket
 import random
@@ -77,6 +77,8 @@ class TestUserAgent(unittest.TestCase):
                         self.assertIn(expected_ua, (None, ""))
                     return True  # 测试成功
 
+            except socket.timeout:
+                continue
             except OSError as e:
                 error_msg = str(e).lower()
                 # 不允许None错误时，网络问题继续尝试，其他错误重新抛出
@@ -88,6 +90,23 @@ class TestUserAgent(unittest.TestCase):
 
         # 所有端点都失败
         return False
+
+    @patch("ddns.util.http.request")
+    def test_user_agent_endpoint_timeout_falls_back(self, mock_request):
+        """Try the next endpoint when a request times out."""
+        response = HttpResponse(200, "OK", {}, json.dumps({"User-Agent": USER_AGENT}))
+        mock_request.side_effect = [socket.timeout("timed out"), response]
+
+        self.assertTrue(self._test_user_agent_with_endpoints(expected_ua=USER_AGENT))
+        self.assertEqual(mock_request.call_count, 2)
+
+    @patch("ddns.util.http.request")
+    def test_user_agent_all_endpoint_timeouts_return_false(self, mock_request):
+        """Report unavailable endpoints after every request times out."""
+        mock_request.side_effect = socket.timeout("timed out")
+
+        self.assertFalse(self._test_user_agent_with_endpoints(expected_ua=USER_AGENT))
+        self.assertEqual(mock_request.call_count, 3)
 
     def test_user_agent_constant(self):
         """测试USER_AGENT常量格式正确"""

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -6,7 +6,7 @@ Test ddns.util.http module
 """
 
 from __future__ import unicode_literals
-from __init__ import patch, unittest, sys
+from __init__ import TEST_HTTP_TIMEOUT, patch, unittest, sys
 import json
 import socket
 import random
@@ -59,7 +59,7 @@ class TestUserAgent(unittest.TestCase):
 
         for endpoint in test_endpoints:
             try:
-                response = request("GET", endpoint, headers=headers, retries=1)
+                response = request("GET", endpoint, headers=headers, retries=0, timeout=TEST_HTTP_TIMEOUT)
                 if response.status == 200:
                     response_data = json.loads(response.body)
                     # 不同的测试站点响应格式可能略有不同
@@ -298,7 +298,9 @@ class TestSendHttpRequest(unittest.TestCase):
         from ddns.util.http import request
 
         try:
-            response = request("GET", "http://postman-echo.com/get?test=ddns&format=json")
+            response = request(
+                "GET", "http://postman-echo.com/get?test=ddns&format=json", retries=0, timeout=TEST_HTTP_TIMEOUT
+            )
             self.assertEqual(response.status, 200)
             self.assertIsNotNone(response.body)
 
@@ -331,7 +333,9 @@ class TestSendHttpRequest(unittest.TestCase):
                 "Content-Type": "application/json",
                 "User-Agent": "DDNS-Client/4.0",
             }
-            response = request("GET", "http://postman-echo.com/status/401", headers=headers)
+            response = request(
+                "GET", "http://postman-echo.com/status/401", headers=headers, retries=0, timeout=TEST_HTTP_TIMEOUT
+            )
             self.assertEqual(response.status, 401)
             self.assertIsNotNone(response.body)
 
@@ -350,7 +354,9 @@ class TestSendHttpRequest(unittest.TestCase):
         from ddns.util.http import request
 
         try:
-            response = request("GET", "https://postman-echo.com/status/200", verify="auto")
+            response = request(
+                "GET", "https://postman-echo.com/status/200", verify="auto", retries=0, timeout=TEST_HTTP_TIMEOUT
+            )
             self.assertEqual(response.status, 200, "SSL auto模式应该成功")
             self.assertIsNotNone(response.body)
 
@@ -369,12 +375,14 @@ class TestSendHttpRequest(unittest.TestCase):
         from ddns.util.http import request
 
         try:
-            response_400 = request("GET", "http://postman-echo.com/status/400")
+            response_400 = request("GET", "http://postman-echo.com/status/400", retries=0, timeout=TEST_HTTP_TIMEOUT)
             self.assertEqual(response_400.status, 400, "应该返回400 Bad Request状态码")
             self.assertIsNotNone(response_400.body, "400响应应该有响应体")
             self.assertIsNotNone(response_400.headers, "400响应应该有响应头")
             self.assertIsNotNone(response_400.reason, "400响应应该有状态原因")
 
+        except socket.timeout as e:
+            self.skipTest("Network unavailable for HTTP 400 status test: {}".format(str(e)))
         except Exception as e:
             # 网络问题时跳过测试
             error_msg = str(e).lower()
@@ -437,7 +445,7 @@ class TestSendHttpRequest(unittest.TestCase):
         for redirect_url in test_endpoints:
             try:
                 # HTTP重定向处理 - GET重定向
-                response = request("GET", redirect_url, verify=False, retries=3)
+                response = request("GET", redirect_url, verify=False, retries=0, timeout=TEST_HTTP_TIMEOUT)
 
                 # 重定向后应该成功
                 if response.status == 200:
@@ -453,6 +461,9 @@ class TestSendHttpRequest(unittest.TestCase):
                     # 5xx错误，尝试下一个端点
                     continue
 
+            except socket.timeout as e:
+                last_exception = e
+                continue
             except Exception as e:
                 last_exception = e
                 # 网络问题时继续尝试下一个端点
@@ -491,7 +502,9 @@ class TestSendHttpRequest(unittest.TestCase):
         for redirect_url in test_endpoints:
             try:
                 post_data = "test=data&method=POST->GET"
-                response_post = request("POST", redirect_url, data=post_data, verify=False, retries=3)
+                response_post = request(
+                    "POST", redirect_url, data=post_data, verify=False, retries=0, timeout=TEST_HTTP_TIMEOUT
+                )
 
                 # 重定向后应该成功
                 if response_post.status == 200:
@@ -506,6 +519,9 @@ class TestSendHttpRequest(unittest.TestCase):
                     # 5xx错误，尝试下一个端点
                     continue
 
+            except socket.timeout as e:
+                last_exception = e
+                continue
             except Exception as e:
                 last_exception = e
                 # 网络问题时继续尝试下一个端点

--- a/tests/test_util_http_proxy_list.py
+++ b/tests/test_util_http_proxy_list.py
@@ -4,7 +4,9 @@
 Test ddns.util.http module proxy list functionality
 """
 
-from __init__ import unittest, patch, MagicMock
+import socket
+
+from __init__ import TEST_HTTP_TIMEOUT, unittest, patch, MagicMock
 from ddns.util.http import request, quote
 
 
@@ -135,7 +137,7 @@ class TestRequestProxyList(unittest.TestCase):
                 proxy_list = ["http://invalid-proxy:9999", None]
 
                 # 这应该在第一个代理失败后回退到直连
-                response = request("GET", url, proxies=proxy_list, retries=3)
+                response = request("GET", url, proxies=proxy_list, retries=0, timeout=TEST_HTTP_TIMEOUT)
 
                 # 如果成功，应该是通过直连完成的
                 if response.status == 200:
@@ -146,6 +148,9 @@ class TestRequestProxyList(unittest.TestCase):
                     # 5xx错误，尝试下一个端点
                     continue
 
+            except socket.timeout as e:
+                last_exception = e
+                continue
             except Exception as e:
                 last_exception = e
                 # 网络问题时继续尝试下一个端点
@@ -186,7 +191,7 @@ class TestRequestProxyList(unittest.TestCase):
                 auth_url = "https://{0}:{1}@{2}/basic-auth/{3}/{4}".format(
                     username_encoded, password_encoded, host, username_encoded, password_encoded
                 )
-                response_auth = request("GET", auth_url, verify=False, retries=2)
+                response_auth = request("GET", auth_url, verify=False, retries=0, timeout=TEST_HTTP_TIMEOUT)
 
                 if response_auth.status == 200:
                     self.assertIn('"auth', response_auth.body)
@@ -200,6 +205,9 @@ class TestRequestProxyList(unittest.TestCase):
                     # 其他状态码也尝试下一个端点
                     continue
 
+            except socket.timeout as e:
+                last_exception = e
+                continue
             except Exception as e:
                 last_exception = e
                 # 网络问题时继续尝试下一个端点

--- a/tests/test_util_http_retry.py
+++ b/tests/test_util_http_retry.py
@@ -269,6 +269,29 @@ class TestRequestFunction(unittest.TestCase):
         self.assertEqual(result.status, 200)
         mock_build_opener.assert_called_once()
 
+    @patch("ddns.util.http.build_opener")
+    def test_request_timeout_defaults_and_override(self, mock_build_opener):
+        """Use method defaults unless the caller supplies a timeout."""
+        mock_response = MagicMock()
+        mock_response.getcode.return_value = 200
+        mock_response.info.return_value = {}
+        mock_response.read.return_value = b"test"
+        mock_response.msg = "OK"
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_response
+        mock_build_opener.return_value = mock_opener
+
+        request("GET", "http://example.com")
+        self.assertEqual(mock_opener.open.call_args[1]["timeout"], 60)
+
+        mock_opener.open.reset_mock()
+        request("POST", "http://example.com")
+        self.assertEqual(mock_opener.open.call_args[1]["timeout"], 120)
+
+        mock_opener.open.reset_mock()
+        request("GET", "http://example.com", timeout=5)
+        self.assertEqual(mock_opener.open.call_args[1]["timeout"], 5)
+
     @patch("time.sleep")
     def test_retry_handler_backoff_delays(self, mock_sleep):
         """测试 RetryHandler 的指数退避延迟"""


### PR DESCRIPTION
CI runs execute several live HTTP integration tests. When provider or echo endpoints stop responding, the existing 60-second GET and 120-second POST defaults can exhaust the Python job's 5-minute limit before the suite finishes.

- Add an optional per-attempt `timeout` to the shared HTTP client while preserving existing production defaults.
- Forward timeout and retry controls through provider HTTP calls and remote configuration loading.
- Run live CI requests with a 5-second timeout and no retries where endpoint fallback already exists.
- Handle `socket.timeout` deterministically so unavailable test endpoints fall back or skip instead of hanging.
- Add regression coverage for timeout forwarding, defaults, fallback recovery, and exhausted endpoints.

Production callers keep the existing GET 60-second and other-request 120-second defaults unless they explicitly provide a timeout.