### PR TITLE
test(e2e): expand binary coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,19 +323,8 @@ jobs:
           set -ex
           for f in output/*/ddns; do
             platform=$(basename $(dirname "$f") | tr '_' '/')
-            if [ "$platform" = "linux/arm/v6" ]; then
-              continue
-            fi
             tests/scripts/test-in-docker.sh $platform ${{matrix.libc}} "$f"
           done
-
-      - uses: docker/setup-qemu-action@v4
-        if: matrix.host == 'arm' && matrix.libc == 'musl'
-        with:
-          platforms: arm
-      - name: Test ARMv6 binary
-        if: matrix.host == 'arm' && matrix.libc == 'musl'
-        run: tests/scripts/test-in-docker.sh linux/arm/v6 musl output/linux_arm_v6/ddns
 
       # 输出目录结构扁平化
       - name: Flatten output directory structure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
       # glibc: 基于 debian linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
       # musl: 基于 alpine  linux/386,linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6
       platforms: ${{ matrix.host == 'amd' && 'linux/386,linux/amd64' || matrix.libc == 'glibc' && 'linux/arm/v7,linux/arm64/v8' || 'linux/arm/v6,linux/arm/v7,linux/arm64/v8' }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,10 +304,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v4
-        if: matrix.host == 'arm' && matrix.libc == 'musl'
-        with:
-          platforms: arm
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:
@@ -327,8 +323,19 @@ jobs:
           set -ex
           for f in output/*/ddns; do
             platform=$(basename $(dirname "$f") | tr '_' '/')
+            if [ "$platform" = "linux/arm/v6" ]; then
+              continue
+            fi
             tests/scripts/test-in-docker.sh $platform ${{matrix.libc}} "$f"
           done
+
+      - uses: docker/setup-qemu-action@v4
+        if: matrix.host == 'arm' && matrix.libc == 'musl'
+        with:
+          platforms: arm
+      - name: Test ARMv6 binary
+        if: matrix.host == 'arm' && matrix.libc == 'musl'
+        run: tests/scripts/test-in-docker.sh linux/arm/v6 musl output/linux_arm_v6/ddns
 
       # 输出目录结构扁平化
       - name: Flatten output directory structure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,10 +300,14 @@ jobs:
       # glibc: 基于 debian linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
       # musl: 基于 alpine  linux/386,linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6
       platforms: ${{ matrix.host == 'amd' && 'linux/386,linux/amd64' || matrix.libc == 'glibc' && 'linux/arm/v7,linux/arm64/v8' || 'linux/arm/v6,linux/arm/v7,linux/arm64/v8' }}
-    timeout-minutes: 8
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
+      - uses: docker/setup-qemu-action@v4
+        if: matrix.host == 'arm' && matrix.libc == 'musl'
+        with:
+          platforms: arm
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -240,10 +240,14 @@ jobs:
       contents: write
     env:
       platforms: ${{ matrix.host == 'amd' && 'linux/386,linux/amd64' || matrix.libc == 'glibc' && 'linux/arm/v7,linux/arm64/v8' || 'linux/arm/v6,linux/arm/v7,linux/arm64/v8' }}
-    timeout-minutes: 8
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
+      - uses: docker/setup-qemu-action@v4
+        if: matrix.host == 'arm' && matrix.libc == 'musl'
+        with:
+          platforms: arm
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -240,7 +240,7 @@ jobs:
       contents: write
     env:
       platforms: ${{ matrix.host == 'amd' && 'linux/386,linux/amd64' || matrix.libc == 'glibc' && 'linux/arm/v7,linux/arm64/v8' || 'linux/arm/v6,linux/arm/v7,linux/arm64/v8' }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -263,19 +263,8 @@ jobs:
           set -ex
           for f in output/*/ddns; do
             platform=$(basename $(dirname "$f") | tr '_' '/')
-            if [ "$platform" = "linux/arm/v6" ]; then
-              continue
-            fi
             tests/scripts/test-in-docker.sh $platform ${{matrix.libc}} "$f"
           done
-
-      - uses: docker/setup-qemu-action@v4
-        if: matrix.host == 'arm' && matrix.libc == 'musl'
-        with:
-          platforms: arm
-      - name: Test ARMv6 binary
-        if: matrix.host == 'arm' && matrix.libc == 'musl'
-        run: tests/scripts/test-in-docker.sh linux/arm/v6 musl output/linux_arm_v6/ddns
 
       # 输出目录结构扁平化
       - name: Flatten output directory structure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -244,10 +244,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v4
-        if: matrix.host == 'arm' && matrix.libc == 'musl'
-        with:
-          platforms: arm
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
         with:
@@ -267,8 +263,19 @@ jobs:
           set -ex
           for f in output/*/ddns; do
             platform=$(basename $(dirname "$f") | tr '_' '/')
+            if [ "$platform" = "linux/arm/v6" ]; then
+              continue
+            fi
             tests/scripts/test-in-docker.sh $platform ${{matrix.libc}} "$f"
           done
+
+      - uses: docker/setup-qemu-action@v4
+        if: matrix.host == 'arm' && matrix.libc == 'musl'
+        with:
+          platforms: arm
+      - name: Test ARMv6 binary
+        if: matrix.host == 'arm' && matrix.libc == 'musl'
+        run: tests/scripts/test-in-docker.sh linux/arm/v6 musl output/linux_arm_v6/ddns
 
       # 输出目录结构扁平化
       - name: Flatten output directory structure

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,9 +66,9 @@ Nuitka 的 Windows、Linux、macOS onefile 构建会通过 `DDNS_E2E_EXECUTABLE`
 
 Nuitka onefile builds for Windows, Linux, and macOS run the same complete suite through `DDNS_E2E_EXECUTABLE`. The executable packaged in the Windows standalone ZIP is tested separately as well.
 
-交叉编译的 Linux glibc/musl 二进制也通过 Docker wrapper 运行同一套离线 CLI 与 MCP 场景，覆盖 386、amd64、ARMv6、ARMv7 和 ARM64；容器通过 host network 访问回环 mock，不使用测试配置中的公网服务。
+交叉编译的 Linux glibc/musl 二进制也通过 Docker wrapper 运行同一套离线 CLI 与 MCP 场景，覆盖 386、amd64、ARMv7 和 ARM64；容器通过 host network 访问回环 mock，不使用测试配置中的公网服务。ARMv6 产物仍会构建，但由于 qemu-user 无法稳定运行 Nuitka onefile，仅执行构建校验。
 
-Cross-compiled Linux glibc/musl binaries run the same offline CLI and MCP scenarios through a Docker wrapper across 386, amd64, ARMv6, ARMv7, and ARM64. The containers reach the loopback mock over host networking instead of using public services from the sample configurations.
+Cross-compiled Linux glibc/musl binaries run the same offline CLI and MCP scenarios through a Docker wrapper across 386, amd64, ARMv7, and ARM64. The containers reach the loopback mock over host networking instead of using public services from the sample configurations. ARMv6 remains build-verified because qemu-user cannot run the Nuitka onefile binary reliably.
 
 Linux systemd 生命周期测试会真实安装、停用、启用并卸载 `ddns.service` 和 `ddns.timer`。它要求运行中的 systemd、免交互 `sudo`，以及测试开始前不存在 DDNS 系统任务；无论成功或失败，脚本都会清理本次创建的任务。
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,25 +46,29 @@ pytest tests/test_provider_he.py -v
 
 ## 端到端测试 / End-to-End Tests
 
-E2E 测试通过真实子进程覆盖 CLI 与本机 Web 控制台，但使用回环 HTTP 服务模拟公网 IP、远程配置和 Callback Provider。因此不需要真实 DNS 凭据，也不会访问公网。
+E2E 测试通过真实子进程覆盖 CLI、本机 Web 控制台与 MCP stdio 服务，但使用回环 HTTP 服务模拟公网 IP、远程配置和 Callback Provider。因此不需要真实 DNS 凭据，也不会访问公网。
 
-The E2E suite exercises the CLI and local Web dashboard through real child processes. A loopback HTTP server simulates public IP discovery, remote configuration, and the Callback Provider, so the suite needs no DNS credentials or Internet access.
+The E2E suite exercises the CLI, local Web dashboard, and MCP stdio server through real child processes. A loopback HTTP server simulates public IP discovery, remote configuration, and the Callback Provider, so the suite needs no DNS credentials or Internet access.
 
 ```bash
-# 独立运行离线 CLI 与 Web E2E / Run the offline CLI and Web E2E suite
+# 独立运行离线 CLI、Web 与 MCP E2E / Run the offline CLI, Web, and MCP E2E suite
 python3 -m unittest tests.e2e -v
 
 # 对已构建的二进制运行同一套 E2E / Run the same suite against a built binary
 DDNS_E2E_EXECUTABLE=./dist/ddns python3 -m unittest tests.e2e -v
 ```
 
-`tests/e2e.py` 不匹配常规 `test_*.py` discovery 规则，由 CI 中独立的 Python 3.12 E2E Job 运行。覆盖范围包括双栈更新、配置优先级、多 Provider、缓存、失败退出码、Web 鉴权、配置 API、同步 API 和 Web 调度器。
+`tests/e2e.py` 不匹配常规 `test_*.py` discovery 规则，由 CI 中独立的 Python 3.12 E2E Job 运行。覆盖范围包括双栈更新、配置生成与优先级、多 Provider、缓存、失败退出码、Web 鉴权与调度器，以及 MCP 现代协议和 Copilot 兼容生命周期。
 
-`tests/e2e.py` intentionally does not match the regular `test_*.py` discovery pattern. A dedicated Python 3.12 CI job runs it and covers dual-stack updates, configuration precedence, multiple providers, caching, failure exit codes, Web authentication, configuration and synchronization APIs, and the Web scheduler.
+`tests/e2e.py` intentionally does not match the regular `test_*.py` discovery pattern. A dedicated Python 3.12 CI job runs it and covers dual-stack updates, configuration generation and precedence, multiple providers, caching, failure exit codes, Web authentication and scheduling, plus both the modern MCP protocol and the Copilot-compatible lifecycle.
 
 Nuitka 的 Windows、Linux、macOS onefile 构建会通过 `DDNS_E2E_EXECUTABLE` 运行全部相同场景；Windows standalone ZIP 中的可执行文件也会单独运行一次完整 E2E。
 
 Nuitka onefile builds for Windows, Linux, and macOS run the same complete suite through `DDNS_E2E_EXECUTABLE`. The executable packaged in the Windows standalone ZIP is tested separately as well.
+
+交叉编译的 Linux glibc/musl 二进制也通过 Docker wrapper 运行同一套离线 CLI 与 MCP 场景，覆盖 386、amd64、ARMv6、ARMv7 和 ARM64；容器通过 host network 访问回环 mock，不使用测试配置中的公网服务。
+
+Cross-compiled Linux glibc/musl binaries run the same offline CLI and MCP scenarios through a Docker wrapper across 386, amd64, ARMv6, ARMv7, and ARM64. The containers reach the loopback mock over host networking instead of using public services from the sample configurations.
 
 Linux systemd 生命周期测试会真实安装、停用、启用并卸载 `ddns.service` 和 `ddns.timer`。它要求运行中的 systemd、免交互 `sudo`，以及测试开始前不存在 DDNS 系统任务；无论成功或失败，脚本都会清理本次创建的任务。
 

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -322,11 +322,12 @@ class OfflineE2ETestCase(unittest.TestCase):
             return [sys.executable, RUN_SCRIPT] + arguments
         return [sys.executable, "-m", "ddns"] + arguments
 
-    def _run(self, arguments, entrypoint="module", env=None, timeout=PROCESS_TIMEOUT):
+    def _run(self, arguments, entrypoint="module", env=None, timeout=PROCESS_TIMEOUT, input_text=None):
         process = subprocess.Popen(
             self._command(arguments, entrypoint),
             cwd=self.temp_dir,
             env=env or self._environment(),
+            stdin=subprocess.PIPE if input_text is not None else None,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
@@ -345,7 +346,7 @@ class OfflineE2ETestCase(unittest.TestCase):
         timer.daemon = True
         timer.start()
         try:
-            stdout, stderr = process.communicate()
+            stdout, stderr = process.communicate(input_text)
         finally:
             timer.cancel()
         if timed_out.is_set():
@@ -496,6 +497,75 @@ class TestCliE2E(OfflineE2ETestCase):
             requests[0]["query"], {"domain": ["cli-env.example.com"], "ip": [TEST_IPV4], "type": ["A"], "ttl": ["120"]}
         )
 
+    def test_generate_config_with_realistic_cli_options_and_reuse_it(self):
+        """Generate a user-style config with a spaced path, then execute it."""
+        config_path = os.path.join(self.temp_dir, "generated user config.json")
+        log_path = os.path.join(self.temp_dir, "generated user.log")
+        callback_path = "/callback/generated"
+        callback_url = (
+            self.fixture_url
+            + callback_path
+            + "?domain=__DOMAIN__&ip=__IP__&type=__RECORDTYPE__&ttl=__TTL__&line=__LINE__"
+        )
+        generate = self._run(
+            [
+                "--dns",
+                "callback",
+                "--id",
+                callback_url,
+                "--token",
+                "{}",
+                "--index4",
+                "url:" + self.fixture_url + "/ip/v4",
+                "--ipv4",
+                "Generated.Example.com",
+                "--ttl",
+                "900",
+                "--line",
+                "generated",
+                "--proxy",
+                "DIRECT",
+                "--no-cache",
+                "--no-ssl",
+                "--log-level",
+                "DEBUG",
+                "--log-file",
+                log_path,
+                "--new-config",
+                config_path,
+            ]
+        )
+
+        self.assert_process_success(generate)
+        self.assertTrue(os.path.isfile(config_path))
+        with io.open(config_path, "r", encoding="utf-8") as generated_file:
+            generated_config = json.load(generated_file)
+        self.assertEqual(generated_config["dns"], "callback")
+        self.assertEqual(generated_config["token"], "{}")
+        self.assertEqual(generated_config["ipv4"], ["Generated.Example.com"])
+        self.assertEqual(generated_config["index4"], ["url:" + self.fixture_url + "/ip/v4"])
+        self.assertEqual(generated_config["proxy"], ["DIRECT"])
+        self.assertFalse(generated_config["cache"])
+        self.assertFalse(generated_config["ssl"])
+
+        result = self._run(["-c", config_path])
+
+        self.assert_process_success(result)
+        requests = self.fixture_state.requests_for(callback_path)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(
+            requests[0]["query"],
+            {
+                "domain": ["generated.example.com"],
+                "ip": [TEST_IPV4],
+                "type": ["A"],
+                "ttl": ["900"],
+                "line": ["generated"],
+            },
+        )
+        with io.open(log_path, "r", encoding="utf-8") as log_file:
+            self.assertIn("generated.example.com", log_file.read())
+
     def test_remote_multi_provider_configuration(self):
         """Load a remote v4.1 document and execute every expanded provider."""
         second_token = json.dumps(
@@ -604,6 +674,181 @@ class TestCliE2E(OfflineE2ETestCase):
         self.assertEqual(len(self.fixture_state.requests_for("/callback/fail")), 1)
         self.assertIn("Configuration 2 failed", result.stderr)
         self.assertIn("Some configurations failed", result.stderr)
+
+
+class TestMcpE2E(OfflineE2ETestCase):
+    """Exercise both supported MCP stdio lifecycles through a real process."""
+
+    MODERN_VERSION = "2026-07-28"
+    LEGACY_VERSION = "2025-11-25"
+
+    def _modern_request(self, request_id, method, params=None):
+        params = dict(params or {})
+        params["_meta"] = {
+            "io.modelcontextprotocol/protocolVersion": self.MODERN_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {"sampling": {}},
+            "io.modelcontextprotocol/clientInfo": {"name": "ddns-e2e-client", "version": "1.0"},
+        }
+        return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+
+    @staticmethod
+    def _request_lines(requests):
+        return "".join(json.dumps(request, ensure_ascii=False, separators=(",", ":")) + "\n" for request in requests)
+
+    def _run_mcp(self, config_path, requests):
+        result = self._run(["mcp", "-c", config_path], input_text=self._request_lines(requests))
+        self.assert_process_success(result)
+        lines = result.stdout.splitlines()
+        self.assertEqual(
+            len(lines),
+            len([request for request in requests if "id" in request]),
+            "Unexpected MCP stdout.\nstdout:\n{}\nstderr:\n{}".format(result.stdout, result.stderr),
+        )
+        return result, [json.loads(line) for line in lines]
+
+    def test_modern_discovery_tools_update_and_cached_status(self):
+        """Discover tools, synchronize dual-stack records, and read cached status."""
+        cache_path = os.path.join(self.temp_dir, "mcp.cache")
+        token = json.dumps(
+            {
+                "api_key": "mcp-secret",
+                "domain": "__DOMAIN__",
+                "ip": "__IP__",
+                "record_type": "__RECORDTYPE__",
+                "ttl": "__TTL__",
+                "line": "__LINE__",
+            },
+            separators=(",", ":"),
+        )
+        config = {
+            "$schema": "https://ddns.newfuture.cc/schema/v4.1.json",
+            "proxy": ["DIRECT"],
+            "ssl": False,
+            "cache": cache_path,
+            "cache_max_age": 3600,
+            "providers": [
+                {
+                    "provider": "callback",
+                    "id": self.fixture_url + "/callback/mcp",
+                    "token": token,
+                    "ipv4": ["mcp-v4.example.com"],
+                    "index4": ["url:" + self.fixture_url + "/ip/v4"],
+                    "ipv6": ["mcp-v6.example.com"],
+                    "index6": ["url:" + self.fixture_url + "/ip/v6"],
+                    "ttl": 720,
+                    "line": "mcp",
+                },
+                {
+                    "provider": "debug",
+                    "ipv4": ["mcp-debug.example.com"],
+                    "index4": ["url:" + self.fixture_url + "/ip/v4"],
+                    "ipv6": [],
+                    "index6": False,
+                    "ttl": 300,
+                },
+            ],
+        }
+        config_path = self._write_config("mcp.json", config)
+        requests = [
+            self._modern_request(1, "server/discover"),
+            self._modern_request(2, "tools/list"),
+            self._modern_request(3, "tools/call", {"name": "update_dns_records", "arguments": {}}),
+            self._modern_request(4, "tools/call", {"name": "get_ddns_status", "arguments": {}}),
+        ]
+
+        result, responses = self._run_mcp(config_path, requests)
+
+        self.assertEqual([response["id"] for response in responses], [1, 2, 3, 4])
+        self.assertEqual(responses[0]["result"]["supportedVersions"], [self.MODERN_VERSION, self.LEGACY_VERSION])
+        tools = responses[1]["result"]["tools"]
+        self.assertEqual([tool["name"] for tool in tools], ["get_ddns_status", "update_dns_records"])
+        self.assertTrue(tools[0]["annotations"]["readOnlyHint"])
+        self.assertTrue(tools[1]["annotations"]["destructiveHint"])
+
+        update = responses[2]["result"]
+        self.assertFalse(update["isError"])
+        self.assertEqual(update["structuredContent"]["state"], "synced")
+        expected_records = [
+            ("mcp-debug.example.com", "A", TEST_IPV4, "debug"),
+            ("mcp-v4.example.com", "A", TEST_IPV4, "callback"),
+            ("mcp-v6.example.com", "AAAA", TEST_IPV6, "callback"),
+        ]
+        self.assertEqual(
+            [
+                (record["domain"], record["type"], record["value"], record["provider"])
+                for record in update["structuredContent"]["records"]
+            ],
+            expected_records,
+        )
+        status = responses[3]["result"]
+        self.assertFalse(status["isError"])
+        self.assertEqual(status["structuredContent"]["state"], "synced")
+        self.assertEqual(
+            [
+                (record["domain"], record["type"], record["value"], record["provider"])
+                for record in status["structuredContent"]["records"]
+            ],
+            expected_records,
+        )
+        self.assertNotIn("mcp-secret", result.stdout)
+        self.assertIn("[IPv4] {}".format(TEST_IPV4), result.stderr)
+
+        callback_requests = self.fixture_state.requests_for("/callback/mcp")
+        self.assertEqual(len(callback_requests), 2)
+        self.assertEqual(
+            sorted((json.loads(request["body"]) for request in callback_requests), key=lambda body: body["domain"]),
+            [
+                {
+                    "api_key": "mcp-secret",
+                    "domain": "mcp-v4.example.com",
+                    "ip": TEST_IPV4,
+                    "record_type": "A",
+                    "ttl": "720",
+                    "line": "mcp",
+                },
+                {
+                    "api_key": "mcp-secret",
+                    "domain": "mcp-v6.example.com",
+                    "ip": TEST_IPV6,
+                    "record_type": "AAAA",
+                    "ttl": "720",
+                    "line": "mcp",
+                },
+            ],
+        )
+
+    def test_legacy_copilot_initialize_ping_list_and_status(self):
+        """Run the lifecycle used by GitHub Copilot CLI over stdio."""
+        config_path = self._write_config(
+            "legacy-mcp.json", self._callback_config("/callback/legacy-mcp", ["legacy.example.com"], cache=False)
+        )
+        requests = [
+            {
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": self.LEGACY_VERSION,
+                    "capabilities": {"sampling": {}},
+                    "clientInfo": {"name": "github-copilot-developer", "version": "1.0.80"},
+                },
+            },
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "get_ddns_status", "arguments": {}}},
+        ]
+
+        _, responses = self._run_mcp(config_path, requests)
+
+        self.assertEqual([response["id"] for response in responses], [0, 1, 2, 3])
+        self.assertEqual(responses[0]["result"]["protocolVersion"], self.LEGACY_VERSION)
+        self.assertEqual(responses[1]["result"], {})
+        self.assertEqual(
+            [tool["name"] for tool in responses[2]["result"]["tools"]], ["get_ddns_status", "update_dns_records"]
+        )
+        self.assertFalse(responses[3]["result"]["isError"])
+        self.assertNotIn("resultType", responses[3]["result"])
 
 
 class TestWebE2E(OfflineE2ETestCase):

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -708,7 +708,6 @@ class TestMcpE2E(OfflineE2ETestCase):
 
     def test_modern_discovery_tools_update_and_cached_status(self):
         """Discover tools, synchronize dual-stack records, and read cached status."""
-        cache_path = os.path.join(self.temp_dir, "mcp.cache")
         token = json.dumps(
             {
                 "api_key": "mcp-secret",
@@ -724,7 +723,7 @@ class TestMcpE2E(OfflineE2ETestCase):
             "$schema": "https://ddns.newfuture.cc/schema/v4.1.json",
             "proxy": ["DIRECT"],
             "ssl": False,
-            "cache": cache_path,
+            "cache": True,
             "cache_max_age": 3600,
             "providers": [
                 {

--- a/tests/scripts/test-in-docker.sh
+++ b/tests/scripts/test-in-docker.sh
@@ -74,7 +74,8 @@ else
             platform="linux/arm_cortex-a15_neon-vfpv4"
             ;;
         linux/arm/v6)
-            container="arm32v6/alpine:3.12"
+            echo "::warning::ARMv6 runtime E2E skipped because qemu-user cannot reliably run the Nuitka onefile binary"
+            exit 0
             ;;
         *)
             container="alpine:3.12"

--- a/tests/scripts/test-in-docker.sh
+++ b/tests/scripts/test-in-docker.sh
@@ -1,16 +1,58 @@
-set -ex
+#!/bin/sh
+
+set -eu
+
+if [ "${E2E_DOCKER_WRAPPER:-}" = "1" ]; then
+    : "${E2E_DOCKER_BINARY:?E2E_DOCKER_BINARY is required}"
+    : "${E2E_DOCKER_IMAGE:?E2E_DOCKER_IMAGE is required}"
+    : "${E2E_DOCKER_PLATFORM:?E2E_DOCKER_PLATFORM is required}"
+
+    binary=$(realpath "$E2E_DOCKER_BINARY")
+    binary_dir=$(dirname "$binary")
+    workdir=$(pwd -P)
+    ddns_env=$(mktemp)
+    trap 'rm -f "$ddns_env"' 0
+    trap 'exit 130' 2
+    trap 'exit 143' 15
+    env | awk '/^DDNS_[A-Za-z0-9_]*=/ && !/^DDNS_E2E_/ { print }' > "$ddns_env"
+
+    set +e
+    docker run \
+        --rm \
+        --interactive \
+        --network host \
+        --volume "$binary_dir:$binary_dir:ro" \
+        --volume "$workdir:$workdir" \
+        --workdir "$workdir" \
+        --platform "$E2E_DOCKER_PLATFORM" \
+        --env HOME \
+        --env USERPROFILE \
+        --env TMPDIR \
+        --env TEMP \
+        --env TMP \
+        --env PYTHONIOENCODING \
+        --env PYTHONUNBUFFERED \
+        --env-file "$ddns_env" \
+        "$E2E_DOCKER_IMAGE" \
+        "$binary" \
+        "$@"
+    status=$?
+    set -e
+    exit "$status"
+fi
+
 platform=${1:-linux/amd64}
 libc=${2:-musl}
-filePath=${3:-dist/ddns}
-
-volume=$(dirname $(realpath "$filePath"))
-file=$(basename "$filePath")
-MAP_CONF="${GITHUB_WORKSPACE}/tests/config:/config"
+file_path=${3:-dist/ddns}
+binary=$(realpath "$file_path")
+volume=$(dirname "$binary")
+file=$(basename "$binary")
+test_scripts=$(dirname "$(realpath "$0")")
 
 if [ "$libc" = "glibc" ]; then
     container="ubuntu:19.04"
 else
-    case $platform in
+    case "$platform" in
         linux/amd64)
             container="openwrt/rootfs:x86_64"
             ;;
@@ -31,42 +73,38 @@ else
             platform="linux/arm_cortex-a15_neon-vfpv4"
             ;;
         linux/arm/v6)
-            # v6 不支持直接测试，需要qume仿真
-            echo "::warn::untested platform '$platform' ($libc)"
-            exit 0
+            container="arm32v6/alpine:3.12"
             ;;
         *)
-        container="alpine"
-        ;;
+            container="alpine:3.12"
+            ;;
     esac
 fi
 
-docker run --rm -v="$volume:/dist" --platform=$platform $container /dist/$file -h
-docker run --rm -v="$volume:/dist" --platform=$platform $container /dist/$file --version
-docker run --rm -v="$volume:/dist" --platform=$platform $container sh -c "/dist/$file || test -f config.json"
-docker run --rm -v="$volume:/dist" -v="$MAP_CONF" --platform=$platform $container /dist/$file -c /config/callback.json
-docker run --rm -v="$volume:/dist" -v="$MAP_CONF" --platform=$platform $container /dist/$file -c /config/debug.json
-docker run --rm -v="$volume:/dist" -v="$MAP_CONF" --platform=$platform $container /dist/$file -c /config/noip.json
+export DDNS_E2E_EXECUTABLE="$test_scripts/test-in-docker.sh"
+export E2E_DOCKER_BINARY="$binary"
+export E2E_DOCKER_IMAGE="$container"
+export E2E_DOCKER_PLATFORM="$platform"
+export E2E_DOCKER_WRAPPER=1
+export PYTHONIOENCODING=utf-8
 
-# Test task subcommand
-echo "Testing task subcommand..."
-docker run --rm -v="$volume:/dist" --platform=$platform $container /dist/$file task --help
-docker run --rm -v="$volume:/dist" --platform=$platform $container /dist/$file task --status
+echo "=== Offline binary E2E: $platform ($libc) in $container ==="
+"$DDNS_E2E_EXECUTABLE" --help
+"$DDNS_E2E_EXECUTABLE" --version
+python3 -m unittest tests.e2e.TestCliE2E tests.e2e.TestMcpE2E -v
 
-# Test task functionality - auto-detect available scheduler
-echo "Testing task management with auto-detection..."
-TEST_SCRIPTS=$(dirname $(realpath "$0"))
+echo "=== Task command smoke test ==="
+"$DDNS_E2E_EXECUTABLE" task --help
+"$DDNS_E2E_EXECUTABLE" task --status
 
-# Determine if privileged mode is needed for systemd support
 if [ "$libc" = "glibc" ]; then
-    # Skip task test in glibc environment due to systemd requiring privileged container
-    echo "Skipping task test in glibc environment (systemd requires privileged container)."
+    echo "Skipping task lifecycle in glibc container because systemd requires a privileged container."
 else
-    echo "Running task test cron..."
-    docker run --rm -v="$volume:/dist" -v="$TEST_SCRIPTS:/scripts" \
-        --platform=$platform $container /scripts/test-task-cron.sh /dist/$file
+    echo "=== Cron task lifecycle ==="
+    docker run --rm \
+        --volume "$volume:/dist:ro" \
+        --volume "$test_scripts:/scripts:ro" \
+        --platform "$platform" \
+        "$container" \
+        /scripts/test-task-cron.sh "/dist/$file"
 fi
-
-
-# delete to avoid being reused
-docker image rm $container

--- a/tests/scripts/test-in-docker.sh
+++ b/tests/scripts/test-in-docker.sh
@@ -109,3 +109,6 @@ else
         "$container" \
         /scripts/test-task-cron.sh "/dist/$file"
 fi
+
+# A shared image tag can resolve to a different architecture for the next binary.
+docker image rm "$container"

--- a/tests/scripts/test-in-docker.sh
+++ b/tests/scripts/test-in-docker.sh
@@ -9,6 +9,7 @@ if [ "${E2E_DOCKER_WRAPPER:-}" = "1" ]; then
 
     binary=$(realpath "$E2E_DOCKER_BINARY")
     binary_dir=$(dirname "$binary")
+    binary_name=$(basename "$binary")
     workdir=$(pwd -P)
     ddns_env=$(mktemp)
     trap 'rm -f "$ddns_env"' 0
@@ -21,7 +22,7 @@ if [ "${E2E_DOCKER_WRAPPER:-}" = "1" ]; then
         --rm \
         --interactive \
         --network host \
-        --volume "$binary_dir:$binary_dir:ro" \
+        --volume "$binary_dir:/dist:ro" \
         --volume "$workdir:$workdir" \
         --workdir "$workdir" \
         --platform "$E2E_DOCKER_PLATFORM" \
@@ -34,7 +35,7 @@ if [ "${E2E_DOCKER_WRAPPER:-}" = "1" ]; then
         --env PYTHONUNBUFFERED \
         --env-file "$ddns_env" \
         "$E2E_DOCKER_IMAGE" \
-        "$binary" \
+        "/dist/$binary_name" \
         "$@"
     status=$?
     set -e


### PR DESCRIPTION
## Summary
- add real MCP stdio E2E coverage for modern and Copilot-compatible lifecycles
- cover generated user configuration, dual-stack multi-provider sync, cached status, protocol output purity, and complete callback payloads
- run the shared offline CLI/MCP suite against cross-compiled glibc and musl binaries on 386, amd64, ARMv7, and ARM64
- keep ARMv6 build verification while documenting the qemu-user limitation for Nuitka onefile execution
- document the expanded binary test matrix

## Validation
- `uv run --python 3.12 --no-project python -m unittest tests.e2e tests.test_mcp tests.test_config_cli_mcp -v`
- `ruff check tests/e2e.py`
- `ruff format --check tests/e2e.py`
- `sh -n tests/scripts/test-in-docker.sh`