### PR TITLE
ci(build): persist incremental compiler caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     branches: ["master", "main"]
   pull_request:
     branches: ["master", "main", "abc"]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -204,6 +205,7 @@ jobs:
       - name: Build Executable
         uses: Nuitka/Nuitka-Action@v1.4
         with:
+          caching-key: ${{ matrix.arch }}
           nuitka-version: 2.8.10
           script-name: run.py
           mode: onefile
@@ -241,6 +243,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: Nuitka/Nuitka-Action@v1.4
         with:
+          caching-key: ${{ matrix.arch }}
           nuitka-version: 2.8.10
           script-name: run.py
           mode: standalone
@@ -343,9 +346,39 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ github.event_name == 'push' && 14 || 3 }}
           
+  prepare-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      builder_ref: ${{ steps.builder.outputs.builder_ref }}
+      builder_hash: ${{ steps.builder.outputs.builder_hash }}
+    steps:
+      - name: Resolve Nuitka builder image
+        id: builder
+        shell: bash
+        run: |
+          set -euo pipefail
+          builder_tag=ghcr.io/newfuture/nuitka-builder:master
+          builder_info="$(docker buildx imagetools inspect "$builder_tag")"
+          digest="$(printf '%s\n' "$builder_info" | awk '$1 == "Digest:" { print $2; exit }')"
+          media_type="$(printf '%s\n' "$builder_info" | awk '$1 == "MediaType:" { print $2; exit }')"
+          builder_hash="${digest#sha256:}"
+
+          case "$media_type" in
+            application/vnd.docker.distribution.manifest.list.v2+json|application/vnd.oci.image.index.v1+json) ;;
+            *) echo "Expected a multi-platform image index, got: $media_type" >&2; exit 1 ;;
+          esac
+          test "${#builder_hash}" -eq 64
+          case "$builder_hash" in
+            *[!0-9a-f]*) echo "Invalid builder digest: $digest" >&2; exit 1 ;;
+          esac
+
+          echo "builder_ref=${builder_tag}@${digest}" >> "$GITHUB_OUTPUT"
+          echo "builder_hash=${builder_hash}" >> "$GITHUB_OUTPUT"
+
   docker:
-    needs: [ python ]
-    timeout-minutes: ${{ matrix.host == 'qemu' && 60 || 30 }} 
+    needs: [ python, prepare-docker ]
+    timeout-minutes: ${{ matrix.host == 'qemu' && 90 || 30 }}
     strategy:
       matrix:
         host: ['amd','arm','qemu']
@@ -359,6 +392,11 @@ jobs:
 
     runs-on: ubuntu-${{ matrix.host == 'arm' && '24.04-arm' || 'latest' }}
     env:
+      CACHE_WRITE: ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'push' &&
+          (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+        }}
       platforms: ${{
         matrix.host == 'amd' && 'linux/386,linux/amd64' ||
           matrix.host == 'arm' && 'linux/arm/v6,linux/arm/v7,linux/arm64/v8'||
@@ -374,6 +412,67 @@ jobs:
         with:
           platforms: ${{ env.platforms }}
       - uses: docker/setup-buildx-action@v4
+        id: buildx
+
+      - name: Restore ccache
+        if: env.CACHE_WRITE == 'true'
+        id: ccache
+        uses: actions/cache@v5
+        with:
+          path: .build-cache/ccache
+          key: ddns-ccache-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-${{ github.sha }}
+          restore-keys: |
+            ddns-ccache-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-
+
+      - name: Restore ccache (read-only)
+        if: env.CACHE_WRITE != 'true'
+        id: ccache_readonly
+        uses: actions/cache/restore@v5
+        with:
+          path: .build-cache/ccache
+          key: ddns-ccache-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-${{ github.sha }}
+          restore-keys: |
+            ddns-ccache-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-
+
+      - name: Restore Nuitka module cache
+        if: env.CACHE_WRITE == 'true'
+        id: nuitka_module
+        uses: actions/cache@v5
+        with:
+          path: .build-cache/nuitka-module
+          key: ddns-nuitka-module-mc7-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-${{ github.sha }}
+          restore-keys: |
+            ddns-nuitka-module-mc7-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-
+
+      - name: Restore Nuitka module cache (read-only)
+        if: env.CACHE_WRITE != 'true'
+        id: nuitka_module_readonly
+        uses: actions/cache/restore@v5
+        with:
+          path: .build-cache/nuitka-module
+          key: ddns-nuitka-module-mc7-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-${{ github.sha }}
+          restore-keys: |
+            ddns-nuitka-module-mc7-v2-${{ matrix.host }}-${{ needs.prepare-docker.outputs.builder_hash }}-
+
+      - name: Prepare compiler cache directories
+        run: mkdir -p .build-cache/ccache .build-cache/nuitka-module
+
+      - name: Restore Docker compiler cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              ".build-cache/ccache": "/root/.cache/ccache",
+              ".build-cache/nuitka-module": "/root/.cache/nuitka-module"
+            }
+          skip-extraction: ${{
+            (steps.ccache.outputs.cache-hit == 'true' ||
+              steps.ccache_readonly.outputs.cache-hit == 'true') &&
+            (steps.nuitka_module.outputs.cache-hit == 'true' ||
+              steps.nuitka_module_readonly.outputs.cache-hit == 'true')
+            }}
+
       - uses: docker/build-push-action@v7
         with:
           context: .
@@ -383,7 +482,7 @@ jobs:
           tags: ddns:test
           outputs: type=oci,dest=./multi-platform-image.tar
           build-args: |
-            BUILDER=ghcr.io/newfuture/nuitka-builder:master
+            BUILDER=${{ needs.prepare-docker.outputs.builder_ref }}
             GITHUB_REF_NAME=${{ github.ref_name }}
 
       # 准备测试环境

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
     branches: ["master", "main"]
   pull_request:
     branches: ["master", "main", "abc"]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -393,9 +392,8 @@ jobs:
     runs-on: ubuntu-${{ matrix.host == 'arm' && '24.04-arm' || 'latest' }}
     env:
       CACHE_WRITE: ${{
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'push' &&
-          (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'))
+        github.event_name == 'push' &&
+        (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
         }}
       platforms: ${{
         matrix.host == 'amd' && 'linux/386,linux/amd64' ||

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,8 @@ RUN find /lib /usr/lib /usr/local/lib -name '*.so*' | sed 's|.*/||' | awk '{prin
 
 FROM ${BUILDER} AS builder
 ARG PATCHELF_VERSION
+ARG TARGETARCH
+ARG TARGETVARIANT
 COPY run.py  .
 COPY ddns ddns
 COPY web web
@@ -47,10 +49,23 @@ RUN if patchelf --version 2>/dev/null | grep -q ' 0[.]18[.]0$'; then \
         && make install \
         && rm -rf /tmp/patchelf.tar.gz "/tmp/patchelf-${PATCHELF_VERSION}"; \
     fi
-RUN python3 -O -m nuitka run.py \
-    --remove-output \
-    --lto=yes \
-    $(cat nuitka_exclude_so.txt)
+RUN --mount=type=cache,target=/root/.cache/ccache,sharing=shared \
+    --mount=type=cache,target=/root/.cache/nuitka-module,sharing=shared \
+    cache_subdir="${TARGETARCH}${TARGETVARIANT:+-${TARGETVARIANT}}" \
+    && export CCACHE_DIR="/root/.cache/ccache/${cache_subdir}" \
+    && export NUITKA_CACHE_DIR_MODULE_CACHE="/root/.cache/nuitka-module/${cache_subdir}" \
+    && mkdir -p "${CCACHE_DIR}" "${NUITKA_CACHE_DIR_MODULE_CACHE}" \
+    && ccache --set-config=compiler_check=content \
+    && ccache --set-config=compression=true \
+    && ccache --set-config=compression_level=6 \
+    && ccache --set-config=max_size=1G \
+    && echo "Nuitka module cache files before build: $(find "${NUITKA_CACHE_DIR_MODULE_CACHE}" -type f | wc -l)" \
+    && python3 -O -m nuitka run.py \
+        --remove-output \
+        --lto=yes \
+        $(cat nuitka_exclude_so.txt) \
+    && echo "Nuitka module cache files after build: $(find "${NUITKA_CACHE_DIR_MODULE_CACHE}" -type f | wc -l)" \
+    && ccache --show-stats
 RUN mkdir /output && cp dist/ddns /output/
 COPY docker/entrypoint.sh /output/
 


### PR DESCRIPTION
## Summary

- persist architecture-isolated ccache and Nuitka module caches for the existing AMD, ARM, and single QEMU Docker jobs
- resolve and pin one immutable Nuitka builder digest per workflow, and raise the QEMU timeout from 60 to 90 minutes
- isolate Nuitka-Action caches by target architecture so Windows x86 and x64 no longer share a cache key

## Results

| Docker job | Cold build | Warm build |
| --- | ---: | ---: |
| AMD | 3m 30s | 1m 33s |
| ARM | 3m 12s | 1m 29s |
| QEMU (ppc64le, riscv64, s390x) | 53m 27s | 17m 35s |

Warm builds reused 46 of 47 C compilation results per target (~97.9%). The module cache restored 300 entries per target. Six cache archives total approximately 96.4 MB.

## Validation

- [Cold-cache Build](https://github.com/NewFuture/DDNS/actions/runs/31991218796)
- [Warm-cache Build](https://github.com/NewFuture/DDNS/actions/runs/31994334199)
- all existing unit, E2E, binary, Docker smoke, and packaging checks passed
- final branch review found no functional or cache-correctness issues

The first post-merge `master` build will cold-start because GitHub cache entries are branch-scoped; subsequent `master` builds can reuse the seeded caches.