### PR TITLE
test(http): handle wrapped network timeouts

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,6 +17,13 @@ try:
 except NameError:  # Python 2
     _TIMEOUT_ERRORS = (socket.timeout,)
 
+try:
+    _STRING_TYPES = (basestring,)  # noqa: F821
+except NameError:  # Python 3
+    _STRING_TYPES = (str,)
+
+_NETWORK_MESSAGE_ERRORS = (IOError, OSError, socket.error)
+_SSL_ERRORS = (ssl.SSLError, getattr(ssl, "CertificateError", ssl.SSLError))
 _NETWORK_ERRNOS = {
     value
     for value in (
@@ -42,8 +49,11 @@ def is_network_error(error, include_ssl=False):
         return True
 
     reason = getattr(error, "reason", None)
-    if reason is not None and reason is not error and is_network_error(reason, include_ssl):
-        return True
+    if reason is not None and reason is not error:
+        if isinstance(reason, _STRING_TYPES):
+            error = reason
+        elif is_network_error(reason, include_ssl):
+            return True
 
     if isinstance(error, (socket.gaierror, socket.herror)):
         return True
@@ -51,8 +61,11 @@ def is_network_error(error, include_ssl=False):
     if getattr(error, "errno", None) in _NETWORK_ERRNOS:
         return True
 
-    if include_ssl and isinstance(error, ssl.SSLError):
+    if include_ssl and isinstance(error, _SSL_ERRORS):
         return True
+
+    if not isinstance(error, _NETWORK_MESSAGE_ERRORS + _STRING_TYPES):
+        return False
 
     error_msg = str(error).lower()
     network_keywords = ["timeout", "timed out", "connection", "resolution", "unreachable", "network"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,11 +3,63 @@
 DDNS Tests Package
 """
 
-import sys
+import errno
 import os
+import socket
+import ssl
+import sys
 import unittest
 
 TEST_HTTP_TIMEOUT = 5
+
+try:
+    _TIMEOUT_ERRORS = (socket.timeout, TimeoutError)
+except NameError:  # Python 2
+    _TIMEOUT_ERRORS = (socket.timeout,)
+
+_NETWORK_ERRNOS = {
+    value
+    for value in (
+        getattr(errno, "ECONNABORTED", None),
+        getattr(errno, "ECONNREFUSED", None),
+        getattr(errno, "ECONNRESET", None),
+        getattr(errno, "EHOSTDOWN", None),
+        getattr(errno, "EHOSTUNREACH", None),
+        getattr(errno, "ENETDOWN", None),
+        getattr(errno, "ENETRESET", None),
+        getattr(errno, "ENETUNREACH", None),
+        getattr(errno, "EPIPE", None),
+        getattr(errno, "ETIMEDOUT", None),
+        10060,  # WSAETIMEDOUT
+    )
+    if value is not None
+}
+
+
+def is_network_error(error, include_ssl=False):
+    """Return whether an exception represents an unavailable test endpoint."""
+    if isinstance(error, _TIMEOUT_ERRORS):
+        return True
+
+    reason = getattr(error, "reason", None)
+    if reason is not None and reason is not error and is_network_error(reason, include_ssl):
+        return True
+
+    if isinstance(error, (socket.gaierror, socket.herror)):
+        return True
+
+    if getattr(error, "errno", None) in _NETWORK_ERRNOS:
+        return True
+
+    if include_ssl and isinstance(error, ssl.SSLError):
+        return True
+
+    error_msg = str(error).lower()
+    network_keywords = ["timeout", "timed out", "connection", "resolution", "unreachable", "network"]
+    if include_ssl:
+        network_keywords.extend(["ssl", "certificate"])
+    return any(keyword in error_msg for keyword in network_keywords)
+
 
 try:
     from unittest import mock  # type: ignore
@@ -16,7 +68,7 @@ except ImportError:  # Python 2
     from mock import patch, MagicMock, call  # type: ignore
     import mock  # type: ignore
 
-__all__ = ["patch", "MagicMock", "unittest", "call", "mock", "TEST_HTTP_TIMEOUT"]
+__all__ = ["patch", "MagicMock", "unittest", "call", "mock", "TEST_HTTP_TIMEOUT", "is_network_error"]
 
 # 添加当前目录到 Python 路径，这样就可以直接导入 test_base
 current_dir = os.path.dirname(__file__)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -6,7 +6,13 @@ Base test utilities and common imports for all provider tests
 
 from functools import partial
 
-from __init__ import TEST_HTTP_TIMEOUT, unittest, patch, MagicMock  # noqa: F401 # Ensure package initialization
+from __init__ import (  # noqa: F401 # Ensure package initialization
+    TEST_HTTP_TIMEOUT,
+    MagicMock,
+    is_network_error,
+    patch,
+    unittest,
+)
 
 
 class BaseProviderTestCase(unittest.TestCase):
@@ -34,4 +40,4 @@ class BaseProviderTestCase(unittest.TestCase):
 
 
 # Export commonly used imports for convenience
-__all__ = ["BaseProviderTestCase", "unittest", "patch", "MagicMock", "TEST_HTTP_TIMEOUT"]
+__all__ = ["BaseProviderTestCase", "unittest", "patch", "MagicMock", "TEST_HTTP_TIMEOUT", "is_network_error"]

--- a/tests/test_provider_callback.py
+++ b/tests/test_provider_callback.py
@@ -11,7 +11,7 @@ import logging
 import random
 import platform
 from time import sleep
-from base_test import BaseProviderTestCase, unittest, patch
+from base_test import BaseProviderTestCase, is_network_error, patch, unittest
 from ddns.provider.callback import CallbackProvider
 
 
@@ -343,6 +343,7 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
             "http://httpbin.org/get?domain=__DOMAIN__&ip=__IP__&record_type=__RECORDTYPE__",
             "http://httpbingo.org/get?domain=__DOMAIN__&ip=__IP__&record_type=__RECORDTYPE__",
         ]
+        random.shuffle(test_endpoints)
 
         domain = "test.example.com"
         ip = "111.111.111.111"
@@ -367,22 +368,9 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
 
             except Exception as e:
                 last_exception = e
-                # 网络问题时继续尝试下一个端点
-                error_msg = str(e).lower()
-                network_keywords = [
-                    "timeout",
-                    "connection",
-                    "resolution",
-                    "unreachable",
-                    "network",
-                    "ssl",
-                    "certificate",
-                ]
-                if any(keyword in error_msg for keyword in network_keywords):
-                    continue  # 尝试下一个端点
-                else:
-                    # 其他异常重新抛出
-                    raise
+                if is_network_error(e, include_ssl=True):
+                    continue
+                raise
 
         # 如果所有端点都失败，跳过测试
         error_info = " - Last error: {}".format(str(last_exception)) if last_exception else ""
@@ -392,6 +380,7 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
         """Test real callback using POST method with JSON data and verify logger calls"""
         # 尝试多个测试端点以提高可靠性
         test_endpoints = ["http://httpbingo.org/post", "http://httpbin.org/post"]
+        random.shuffle(test_endpoints)
 
         token = '{"domain": "__DOMAIN__", "ip": "__IP__", "record_type": "__RECORDTYPE__", "ttl": "__TTL__"}'
         domain = "test.example.com"
@@ -420,22 +409,9 @@ class TestCallbackProviderRealIntegration(BaseProviderTestCase):
 
             except Exception as e:
                 last_exception = e
-                # 网络问题时继续尝试下一个端点
-                error_msg = str(e).lower()
-                network_keywords = [
-                    "timeout",
-                    "connection",
-                    "resolution",
-                    "unreachable",
-                    "network",
-                    "ssl",
-                    "certificate",
-                ]
-                if any(keyword in error_msg for keyword in network_keywords):
-                    continue  # 尝试下一个端点
-                else:
-                    # 其他异常重新抛出
-                    raise
+                if is_network_error(e, include_ssl=True):
+                    continue
+                raise
 
         # 如果所有端点都失败，跳过测试
         error_info = " - Last error: {}".format(str(last_exception)) if last_exception else ""

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -6,12 +6,17 @@ Test ddns.util.http module
 """
 
 from __future__ import unicode_literals
-from __init__ import TEST_HTTP_TIMEOUT, patch, unittest, sys
+from __init__ import TEST_HTTP_TIMEOUT, is_network_error, patch, unittest, sys
 import json
 import socket
 import random
 
 from ddns.util.http import HttpResponse, _decode_response_body, quote, USER_AGENT
+
+try:
+    from urllib.error import URLError
+except ImportError:
+    from urllib2 import URLError  # type: ignore[no-redef]
 
 # Python 2/3 compatibility
 if sys.version_info[0] == 2:  # python 2
@@ -77,36 +82,44 @@ class TestUserAgent(unittest.TestCase):
                         self.assertIn(expected_ua, (None, ""))
                     return True  # 测试成功
 
-            except socket.timeout:
-                continue
-            except OSError as e:
-                error_msg = str(e).lower()
-                # 不允许None错误时，网络问题继续尝试，其他错误重新抛出
-                network_keywords = ["timeout", "connection", "resolution", "unreachable", "network"]
-                if not any(keyword in error_msg for keyword in network_keywords):
-                    # 如果不是网络问题，重新抛出异常
-                    raise
-                continue
+            except Exception as e:
+                if is_network_error(e):
+                    continue
+                raise
 
         # 所有端点都失败
         return False
 
+    @patch.object(random, "shuffle")
     @patch("ddns.util.http.request")
-    def test_user_agent_endpoint_timeout_falls_back(self, mock_request):
-        """Try the next endpoint when a request times out."""
+    def test_user_agent_wrapped_timeout_falls_back(self, mock_request, mock_shuffle):
+        """Try the next endpoint when URLError wraps a socket timeout."""
         response = HttpResponse(200, "OK", {}, json.dumps({"User-Agent": USER_AGENT}))
-        mock_request.side_effect = [socket.timeout("timed out"), response]
+        mock_request.side_effect = [URLError(socket.timeout("timed out")), response]
 
         self.assertTrue(self._test_user_agent_with_endpoints(expected_ua=USER_AGENT))
         self.assertEqual(mock_request.call_count, 2)
+        mock_shuffle.assert_called_once()
 
+    @patch.object(random, "shuffle")
     @patch("ddns.util.http.request")
-    def test_user_agent_all_endpoint_timeouts_return_false(self, mock_request):
-        """Report unavailable endpoints after every request times out."""
-        mock_request.side_effect = socket.timeout("timed out")
+    def test_user_agent_all_wrapped_timeouts_return_false(self, mock_request, mock_shuffle):
+        """Report unavailable endpoints after every wrapped timeout."""
+        mock_request.side_effect = URLError(socket.timeout("timed out"))
 
         self.assertFalse(self._test_user_agent_with_endpoints(expected_ua=USER_AGENT))
         self.assertEqual(mock_request.call_count, 3)
+        mock_shuffle.assert_called_once()
+
+    @patch.object(random, "shuffle")
+    @patch("ddns.util.http.request")
+    def test_user_agent_non_network_error_is_raised(self, mock_request, mock_shuffle):
+        """Do not hide genuine non-network failures."""
+        mock_request.side_effect = ValueError("invalid response")
+
+        with self.assertRaises(ValueError):
+            self._test_user_agent_with_endpoints(expected_ua=USER_AGENT)
+        mock_shuffle.assert_called_once()
 
     def test_user_agent_constant(self):
         """测试USER_AGENT常量格式正确"""
@@ -313,15 +326,10 @@ class TestSendHttpRequest(unittest.TestCase):
             self.assertIsInstance(data, dict)
             self.assertTrue(len(data) > 0)
 
-        except (socket.timeout, ConnectionError) as e:
-            self.skipTest("Network unavailable: {}".format(str(e)))
         except Exception as e:
-            error_msg = str(e).lower()
-            network_keywords = ["timeout", "connection", "resolution", "unreachable", "network"]
-            if any(keyword in error_msg for keyword in network_keywords):
+            if is_network_error(e):
                 self.skipTest("Network unavailable for GET request test: {}".format(str(e)))
-            else:
-                raise
+            raise
 
     def test_http_401_status_code_with_headers(self):
         """测试HTTP 401认证失败状态码处理"""
@@ -339,15 +347,10 @@ class TestSendHttpRequest(unittest.TestCase):
             self.assertEqual(response.status, 401)
             self.assertIsNotNone(response.body)
 
-        except (socket.timeout, ConnectionError) as e:
-            self.skipTest("Network unavailable: {}".format(str(e)))
         except Exception as e:
-            error_msg = str(e).lower()
-            network_keywords = ["timeout", "connection", "resolution", "unreachable", "network"]
-            if any(keyword in error_msg for keyword in network_keywords):
+            if is_network_error(e):
                 self.skipTest("Network unavailable for 401 status test: {}".format(str(e)))
-            else:
-                raise
+            raise
 
     def test_ssl_auto_mode(self):
         """测试SSL auto模式"""
@@ -360,15 +363,10 @@ class TestSendHttpRequest(unittest.TestCase):
             self.assertEqual(response.status, 200, "SSL auto模式应该成功")
             self.assertIsNotNone(response.body)
 
-        except (socket.timeout, ConnectionError) as e:
-            self.skipTest("Network unavailable: {}".format(str(e)))
         except Exception as e:
-            error_msg = str(e).lower()
-            network_keywords = ["timeout", "connection", "resolution", "unreachable", "network", "ssl", "certificate"]
-            if any(keyword in error_msg for keyword in network_keywords):
+            if is_network_error(e, include_ssl=True):
                 self.skipTest("Network or SSL unavailable for SSL auto test: {}".format(str(e)))
-            else:
-                raise
+            raise
 
     def test_http_400_status_code(self):
         """测试HTTP 400 Bad Request状态码"""
@@ -381,17 +379,10 @@ class TestSendHttpRequest(unittest.TestCase):
             self.assertIsNotNone(response_400.headers, "400响应应该有响应头")
             self.assertIsNotNone(response_400.reason, "400响应应该有状态原因")
 
-        except socket.timeout as e:
-            self.skipTest("Network unavailable for HTTP 400 status test: {}".format(str(e)))
         except Exception as e:
-            # 网络问题时跳过测试
-            error_msg = str(e).lower()
-            network_keywords = ["timeout", "connection", "resolution", "unreachable", "network"]
-            if any(keyword in error_msg for keyword in network_keywords):
+            if is_network_error(e):
                 self.skipTest("Network unavailable for HTTP 400 status test: {}".format(str(e)))
-            else:
-                # 其他异常重新抛出
-                raise
+            raise
 
     def test_basic_auth_with_url_embedding(self):
         """测试URL嵌入式基本认证格式"""
@@ -439,6 +430,7 @@ class TestSendHttpRequest(unittest.TestCase):
             "http://httpbin.org/redirect-to?url=http://httpbin.org/get",
             "http://httpbingo.org/redirect-to?url=http://httpbingo.org/get",
         ]
+        random.shuffle(test_endpoints)
 
         last_exception = None
 
@@ -461,27 +453,11 @@ class TestSendHttpRequest(unittest.TestCase):
                     # 5xx错误，尝试下一个端点
                     continue
 
-            except socket.timeout as e:
-                last_exception = e
-                continue
             except Exception as e:
                 last_exception = e
-                # 网络问题时继续尝试下一个端点
-                error_msg = str(e).lower()
-                network_keywords = [
-                    "timeout",
-                    "connection",
-                    "resolution",
-                    "unreachable",
-                    "network",
-                    "ssl",
-                    "certificate",
-                ]
-                if any(keyword in error_msg for keyword in network_keywords):
-                    continue  # 尝试下一个端点
-                else:
-                    # 其他异常重新抛出
-                    raise
+                if is_network_error(e, include_ssl=True):
+                    continue
+                raise
 
         # 如果所有端点都失败，跳过测试
         error_info = " - Last error: {}".format(str(last_exception)) if last_exception else ""
@@ -496,6 +472,7 @@ class TestSendHttpRequest(unittest.TestCase):
             "http://httpbingo.org/redirect-to?url=/get",
             "http://httpbin.org/redirect-to?url=http://httpbin.org/get",
         ]
+        random.shuffle(test_endpoints)
 
         last_exception = None
 
@@ -519,27 +496,11 @@ class TestSendHttpRequest(unittest.TestCase):
                     # 5xx错误，尝试下一个端点
                     continue
 
-            except socket.timeout as e:
-                last_exception = e
-                continue
             except Exception as e:
                 last_exception = e
-                # 网络问题时继续尝试下一个端点
-                error_msg = str(e).lower()
-                network_keywords = [
-                    "timeout",
-                    "connection",
-                    "resolution",
-                    "unreachable",
-                    "network",
-                    "ssl",
-                    "certificate",
-                ]
-                if any(keyword in error_msg for keyword in network_keywords):
-                    continue  # 尝试下一个端点
-                else:
-                    # 其他异常重新抛出
-                    raise
+                if is_network_error(e, include_ssl=True):
+                    continue
+                raise
 
         # 如果所有端点都失败，跳过测试
         error_info = " - Last error: {}".format(str(last_exception)) if last_exception else ""

--- a/tests/test_util_http.py
+++ b/tests/test_util_http.py
@@ -7,9 +7,11 @@ Test ddns.util.http module
 
 from __future__ import unicode_literals
 from __init__ import TEST_HTTP_TIMEOUT, is_network_error, patch, unittest, sys
+import errno
 import json
-import socket
 import random
+import socket
+import ssl
 
 from ddns.util.http import HttpResponse, _decode_response_body, quote, USER_AGENT
 
@@ -43,6 +45,35 @@ def byte_string(s):
     if isinstance(s, text_type):
         return s.encode("utf-8")
     return s
+
+
+class TestNetworkError(unittest.TestCase):
+    """Test deterministic network error classification."""
+
+    def test_recognizes_network_errors(self):
+        """Recognize direct, wrapped, errno, and string transport failures."""
+        errors = (
+            socket.gaierror(-2, "Name or service not known"),
+            URLError(socket.gaierror(-2, "Name or service not known")),
+            OSError(errno.ECONNREFUSED, "Connection refused"),
+            URLError("connection refused"),
+        )
+
+        for error in errors:
+            self.assertTrue(is_network_error(error), "Expected network error: {!r}".format(error))
+
+    def test_ssl_error_requires_opt_in(self):
+        """Only classify SSL failures when the caller opts in."""
+        error = ssl.SSLError("certificate verify failed")
+
+        self.assertFalse(is_network_error(error))
+        self.assertTrue(is_network_error(error, include_ssl=True))
+
+    def test_rejects_unrelated_exception(self):
+        """Do not classify application failures by message alone."""
+        error = AssertionError("response connection field is invalid")
+
+        self.assertFalse(is_network_error(error))
 
 
 class TestUserAgent(unittest.TestCase):
@@ -115,9 +146,9 @@ class TestUserAgent(unittest.TestCase):
     @patch("ddns.util.http.request")
     def test_user_agent_non_network_error_is_raised(self, mock_request, mock_shuffle):
         """Do not hide genuine non-network failures."""
-        mock_request.side_effect = ValueError("invalid response")
+        mock_request.side_effect = AssertionError("response connection field is invalid")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AssertionError):
             self._test_user_agent_with_endpoints(expected_ua=USER_AGENT)
         mock_shuffle.assert_called_once()
 

--- a/tests/test_util_http_proxy_list.py
+++ b/tests/test_util_http_proxy_list.py
@@ -4,9 +4,9 @@
 Test ddns.util.http module proxy list functionality
 """
 
-import socket
+import random
 
-from __init__ import TEST_HTTP_TIMEOUT, unittest, patch, MagicMock
+from __init__ import TEST_HTTP_TIMEOUT, MagicMock, is_network_error, patch, unittest
 from ddns.util.http import request, quote
 
 
@@ -126,8 +126,9 @@ class TestRequestProxyList(unittest.TestCase):
 
     def test_real_network_proxy_fallback(self):
         """测试真实网络环境下的代理失败回退（如果网络可用）"""
-        # 尝试多个测试端点以提高可靠性，优先使用httpbin
+        # 尝试多个测试端点以提高可靠性
         test_endpoints = ["http://httpbin.org/get", "http://httpbingo.org/get"]
+        random.shuffle(test_endpoints)
 
         last_exception = None
 
@@ -148,19 +149,11 @@ class TestRequestProxyList(unittest.TestCase):
                     # 5xx错误，尝试下一个端点
                     continue
 
-            except socket.timeout as e:
-                last_exception = e
-                continue
             except Exception as e:
                 last_exception = e
-                # 网络问题时继续尝试下一个端点
-                error_msg = str(e).lower()
-                network_keywords = ["timeout", "connection", "resolution", "unreachable", "network"]
-                if any(keyword in error_msg for keyword in network_keywords):
-                    continue  # 尝试下一个端点
-                else:
-                    # 其他异常重新抛出
-                    raise
+                if is_network_error(e):
+                    continue
+                raise
 
         # 如果所有端点都失败，跳过测试
         error_info = " - Last error: {}".format(str(last_exception)) if last_exception else ""
@@ -180,8 +173,9 @@ class TestRequestProxyList(unittest.TestCase):
         self.assertEqual(username_encoded, "user%40test.com")
         self.assertEqual(password_encoded, "passwo.rd")
 
-        # 尝试多个测试端点以提高可靠性，优先使用httpbingo
+        # 尝试多个测试端点以提高可靠性
         test_hosts = ["httpbingo.org", "httpbin.org"]
+        random.shuffle(test_hosts)
 
         last_exception = None
 
@@ -205,27 +199,11 @@ class TestRequestProxyList(unittest.TestCase):
                     # 其他状态码也尝试下一个端点
                     continue
 
-            except socket.timeout as e:
-                last_exception = e
-                continue
             except Exception as e:
                 last_exception = e
-                # 网络问题时继续尝试下一个端点
-                error_msg = str(e).lower()
-                network_keywords = [
-                    "timeout",
-                    "connection",
-                    "resolution",
-                    "unreachable",
-                    "network",
-                    "ssl",
-                    "certificate",
-                ]
-                if any(keyword in error_msg for keyword in network_keywords):
-                    continue  # 尝试下一个端点
-                else:
-                    # 其他异常重新抛出
-                    raise
+                if is_network_error(e, include_ssl=True):
+                    continue
+                raise
 
         # 如果所有端点都失败，跳过测试
         error_info = " - Last error: {}".format(str(last_exception)) if last_exception else ""


### PR DESCRIPTION
## Summary

- centralize live-test network failure classification, recursively inspecting `URLError.reason` and recognizing socket timeout, DNS, network errno, and optional SSL failures while re-raising non-network exceptions
- shuffle every non-semantic multi-server live endpoint list used by user-agent, redirect, proxy, basic-auth, and callback tests to distribute CI traffic
- cover wrapped `URLError(socket.timeout(...))` fallback and endpoint exhaustion with deterministic mocked regression tests

## Validation

- `uv run --python 3.13 --no-project python -m unittest tests.test_util_http tests.test_util_http_proxy_list tests.test_provider_callback -v` (58 passed)
- `uv run --python 3.13 --no-project python -m unittest discover tests -v` (1,068 passed, 22 skipped)
- `ruff check .`
- `ruff format --check tests/__init__.py tests/base_test.py tests/test_util_http.py tests/test_util_http_proxy_list.py tests/test_provider_callback.py`