### PR TITLE
fix(ci): set GitHub release repository context

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -576,6 +576,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           test -n "$(find assets -maxdepth 1 -type f -print -quit)"


### PR DESCRIPTION
Fixes the GitHub Release creation failure in Publish run [33145794013](https://github.com/NewFuture/DDNS/actions/runs/33145794013), job [98774796680](https://github.com/NewFuture/DDNS/actions/runs/33145794013/job/98774796680).

All builds plus PyPI and Docker publication succeeded; GitHub Release creation failed because `publish-github` intentionally runs without a repository checkout and `gh release` had no explicit repository context. This adds `GH_REPO: ${{ github.repository }}` beside `GH_TOKEN` for that release step.

This fixes future non-checkout release commands only. It does not publish or mutate releases, tags, packages, images, or repository settings.